### PR TITLE
Daily View 구현, Monthly Weekly 와 연동

### DIFF
--- a/checky/checky.xcodeproj/project.pbxproj
+++ b/checky/checky.xcodeproj/project.pbxproj
@@ -54,6 +54,8 @@
 		DA4E4A39290A529200CF45E2 /* WeeklyCalendarHelperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A38290A529200CF45E2 /* WeeklyCalendarHelperTest.swift */; };
 		DA4E4A42290AEC9800CF45E2 /* MonthlyStackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A41290AEC9800CF45E2 /* MonthlyStackViewModel.swift */; };
 		DA4E4A44290AECE500CF45E2 /* MonthlyStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A43290AECE500CF45E2 /* MonthlyStackView.swift */; };
+		DA4E4A46290C288600CF45E2 /* WeeklyStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A45290C288600CF45E2 /* WeeklyStackView.swift */; };
+		DA4E4A48290C289600CF45E2 /* WeeklyStackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A47290C289600CF45E2 /* WeeklyStackViewModel.swift */; };
 		DA91E7D628EABDED0091B6A3 /* Week.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D528EABDED0091B6A3 /* Week.swift */; };
 		DA91E7D828EB57AF0091B6A3 /* DateValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D728EB57AF0091B6A3 /* DateValue.swift */; };
 		DA91E7DA28EB58310091B6A3 /* Extension+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D928EB58310091B6A3 /* Extension+Date.swift */; };
@@ -134,6 +136,8 @@
 		DA4E4A38290A529200CF45E2 /* WeeklyCalendarHelperTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyCalendarHelperTest.swift; sourceTree = "<group>"; };
 		DA4E4A41290AEC9800CF45E2 /* MonthlyStackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyStackViewModel.swift; sourceTree = "<group>"; };
 		DA4E4A43290AECE500CF45E2 /* MonthlyStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyStackView.swift; sourceTree = "<group>"; };
+		DA4E4A45290C288600CF45E2 /* WeeklyStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyStackView.swift; sourceTree = "<group>"; };
+		DA4E4A47290C289600CF45E2 /* WeeklyStackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyStackViewModel.swift; sourceTree = "<group>"; };
 		DA91E7D528EABDED0091B6A3 /* Week.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Week.swift; sourceTree = "<group>"; };
 		DA91E7D728EB57AF0091B6A3 /* DateValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateValue.swift; sourceTree = "<group>"; };
 		DA91E7D928EB58310091B6A3 /* Extension+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+Date.swift"; sourceTree = "<group>"; };
@@ -312,6 +316,8 @@
 		86F0B2BF28F6B681006E2536 /* WeeklyView */ = {
 			isa = PBXGroup;
 			children = (
+				DA4E4A45290C288600CF45E2 /* WeeklyStackView.swift */,
+				DA4E4A47290C289600CF45E2 /* WeeklyStackViewModel.swift */,
 				86F0B2C028F6B71A006E2536 /* WeeklyView.swift */,
 				86F0B2C228F6B726006E2536 /* WeeklyViewModel.swift */,
 				86F0B2C428F6B969006E2536 /* WeeklyCellView.swift */,
@@ -584,6 +590,7 @@
 				DA91E7E528EC94180091B6A3 /* MonthlyCellView.swift in Sources */,
 				DA3E9DAC29078FE200E72E21 /* Extension+Color.swift in Sources */,
 				DA91E81828EE01790091B6A3 /* HeaderViewModel.swift in Sources */,
+				DA4E4A46290C288600CF45E2 /* WeeklyStackView.swift in Sources */,
 				DA2C798328F7268F00922C47 /* ReminderCreateAndEditViewModel.swift in Sources */,
 				DA3E9DAA2907810E00E72E21 /* ButtonStyle.swift in Sources */,
 				DA4E4A44290AECE500CF45E2 /* MonthlyStackView.swift in Sources */,
@@ -599,6 +606,7 @@
 				868C544528F4199D006A9B38 /* CheckyMainView.swift in Sources */,
 				860F766428FCB97A00CB034B /* CalendarView.swift in Sources */,
 				DA2C796828EF007900922C47 /* NavigationTranisitionStyle.swift in Sources */,
+				DA4E4A48290C289600CF45E2 /* WeeklyStackViewModel.swift in Sources */,
 				86F0B2C128F6B71A006E2536 /* WeeklyView.swift in Sources */,
 				DA91E7D828EB57AF0091B6A3 /* DateValue.swift in Sources */,
 				86795899290A3C2D001D5C7F /* ManagerProtocol.swift in Sources */,

--- a/checky/checky.xcodeproj/project.pbxproj
+++ b/checky/checky.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		DA4E4A44290AECE500CF45E2 /* MonthlyStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A43290AECE500CF45E2 /* MonthlyStackView.swift */; };
 		DA4E4A46290C288600CF45E2 /* WeeklyStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A45290C288600CF45E2 /* WeeklyStackView.swift */; };
 		DA4E4A48290C289600CF45E2 /* WeeklyStackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A47290C289600CF45E2 /* WeeklyStackViewModel.swift */; };
+		DA4E4A4B290C74F800CF45E2 /* DailyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A4A290C74F800CF45E2 /* DailyView.swift */; };
 		DA91E7D628EABDED0091B6A3 /* Week.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D528EABDED0091B6A3 /* Week.swift */; };
 		DA91E7D828EB57AF0091B6A3 /* DateValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D728EB57AF0091B6A3 /* DateValue.swift */; };
 		DA91E7DA28EB58310091B6A3 /* Extension+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D928EB58310091B6A3 /* Extension+Date.swift */; };
@@ -138,6 +139,7 @@
 		DA4E4A43290AECE500CF45E2 /* MonthlyStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyStackView.swift; sourceTree = "<group>"; };
 		DA4E4A45290C288600CF45E2 /* WeeklyStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyStackView.swift; sourceTree = "<group>"; };
 		DA4E4A47290C289600CF45E2 /* WeeklyStackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyStackViewModel.swift; sourceTree = "<group>"; };
+		DA4E4A4A290C74F800CF45E2 /* DailyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyView.swift; sourceTree = "<group>"; };
 		DA91E7D528EABDED0091B6A3 /* Week.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Week.swift; sourceTree = "<group>"; };
 		DA91E7D728EB57AF0091B6A3 /* DateValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateValue.swift; sourceTree = "<group>"; };
 		DA91E7D928EB58310091B6A3 /* Extension+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+Date.swift"; sourceTree = "<group>"; };
@@ -256,6 +258,7 @@
 			children = (
 				860F766328FCB97A00CB034B /* CalendarView.swift */,
 				860F766528FCB98500CB034B /* CaledarViewModel.swift */,
+				DA4E4A49290C74E100CF45E2 /* DailyView */,
 				865BE51D28EC464700305899 /* HeaderView */,
 				86F0B2BE28F6B667006E2536 /* MonthlyView */,
 				86F0B2BF28F6B681006E2536 /* WeeklyView */,
@@ -431,6 +434,14 @@
 				DA4E4A38290A529200CF45E2 /* WeeklyCalendarHelperTest.swift */,
 			);
 			path = checkyTests;
+			sourceTree = "<group>";
+		};
+		DA4E4A49290C74E100CF45E2 /* DailyView */ = {
+			isa = PBXGroup;
+			children = (
+				DA4E4A4A290C74F800CF45E2 /* DailyView.swift */,
+			);
+			path = DailyView;
 			sourceTree = "<group>";
 		};
 		DA91E7DF28EC8DDB0091B6A3 /* Model */ = {
@@ -612,6 +623,7 @@
 				86795899290A3C2D001D5C7F /* ManagerProtocol.swift in Sources */,
 				8647B0892907B13C00EE1DA8 /* CalendarCanDoProtocol.swift in Sources */,
 				8647B0872907B11A00EE1DA8 /* MonthlyCalendarHelper.swift in Sources */,
+				DA4E4A4B290C74F800CF45E2 /* DailyView.swift in Sources */,
 				8647AFBC28FD639100EE1DA8 /* WeeklyCellViewModel.swift in Sources */,
 				DA91E81428EDF3900091B6A3 /* MonthlyViewModel.swift in Sources */,
 				DA2C797128F6E2C800922C47 /* Extension+View.swift in Sources */,

--- a/checky/checky.xcodeproj/project.pbxproj
+++ b/checky/checky.xcodeproj/project.pbxproj
@@ -452,8 +452,8 @@
 			isa = PBXGroup;
 			children = (
 				DA4E4A4A290C74F800CF45E2 /* DailyView.swift */,
-				DA2789942911C7F300E76B53 /* DailyHeaderView.swift */,
 				DA4E4A4E290C8ADA00CF45E2 /* DailyViewModel.swift */,
+				DA2789942911C7F300E76B53 /* DailyHeaderView.swift */,
 				DA4E4A4C290C78C700CF45E2 /* DailyCellView.swift */,
 				DA78BC76290FE5E900E2E2AD /* DailyCellViewModel.swift */,
 				DA78BC74290FC63F00E2E2AD /* DailyReminderCellView.swift */,

--- a/checky/checky.xcodeproj/project.pbxproj
+++ b/checky/checky.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		86FC8CF528EAB3CF00B7752F /* DateHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FC8CF428EAB3CF00B7752F /* DateHolder.swift */; };
 		86FC8CF828EAB42500B7752F /* WeeklyCalenderHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FC8CF728EAB42500B7752F /* WeeklyCalenderHelper.swift */; };
 		86FC8CFA28EAB49B00B7752F /* HeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86FC8CF928EAB49B00B7752F /* HeaderView.swift */; };
+		DA2789952911C7F300E76B53 /* DailyHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2789942911C7F300E76B53 /* DailyHeaderView.swift */; };
 		DA2C796128EEFF7700922C47 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2C796028EEFF7700922C47 /* AppDelegate.swift */; };
 		DA2C796328EEFFA300922C47 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2C796228EEFFA300922C47 /* SceneDelegate.swift */; };
 		DA2C796628EF005B00922C47 /* NavigationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2C796528EF005B00922C47 /* NavigationRouter.swift */; };
@@ -119,6 +120,7 @@
 		86FC8CF428EAB3CF00B7752F /* DateHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateHolder.swift; sourceTree = "<group>"; };
 		86FC8CF728EAB42500B7752F /* WeeklyCalenderHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyCalenderHelper.swift; sourceTree = "<group>"; };
 		86FC8CF928EAB49B00B7752F /* HeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
+		DA2789942911C7F300E76B53 /* DailyHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyHeaderView.swift; sourceTree = "<group>"; };
 		DA2C796028EEFF7700922C47 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DA2C796228EEFFA300922C47 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		DA2C796528EF005B00922C47 /* NavigationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationRouter.swift; sourceTree = "<group>"; };
@@ -450,6 +452,7 @@
 			isa = PBXGroup;
 			children = (
 				DA4E4A4A290C74F800CF45E2 /* DailyView.swift */,
+				DA2789942911C7F300E76B53 /* DailyHeaderView.swift */,
 				DA4E4A4E290C8ADA00CF45E2 /* DailyViewModel.swift */,
 				DA4E4A4C290C78C700CF45E2 /* DailyCellView.swift */,
 				DA78BC76290FE5E900E2E2AD /* DailyCellViewModel.swift */,
@@ -607,6 +610,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DA466EA228E685D70076AEE4 /* MonthlyView.swift in Sources */,
+				DA2789952911C7F300E76B53 /* DailyHeaderView.swift in Sources */,
 				DA91E7D628EABDED0091B6A3 /* Week.swift in Sources */,
 				DA2C796128EEFF7700922C47 /* AppDelegate.swift in Sources */,
 				8679589B290A3C64001D5C7F /* ReminderManager.swift in Sources */,

--- a/checky/checky.xcodeproj/project.pbxproj
+++ b/checky/checky.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		DA466EA728E685D90076AEE4 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DA466EA628E685D90076AEE4 /* Preview Assets.xcassets */; };
 		DA4E4A052908F42100CF45E2 /* CreateSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A042908F42100CF45E2 /* CreateSelectorView.swift */; };
 		DA4E4A39290A529200CF45E2 /* WeeklyCalendarHelperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A38290A529200CF45E2 /* WeeklyCalendarHelperTest.swift */; };
+		DA4E4A42290AEC9800CF45E2 /* MonthlyStackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A41290AEC9800CF45E2 /* MonthlyStackViewModel.swift */; };
+		DA4E4A44290AECE500CF45E2 /* MonthlyStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A43290AECE500CF45E2 /* MonthlyStackView.swift */; };
 		DA91E7D628EABDED0091B6A3 /* Week.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D528EABDED0091B6A3 /* Week.swift */; };
 		DA91E7D828EB57AF0091B6A3 /* DateValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D728EB57AF0091B6A3 /* DateValue.swift */; };
 		DA91E7DA28EB58310091B6A3 /* Extension+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D928EB58310091B6A3 /* Extension+Date.swift */; };
@@ -130,6 +132,8 @@
 		DA4E4A042908F42100CF45E2 /* CreateSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateSelectorView.swift; sourceTree = "<group>"; };
 		DA4E4A36290A529100CF45E2 /* checkyTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = checkyTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA4E4A38290A529200CF45E2 /* WeeklyCalendarHelperTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyCalendarHelperTest.swift; sourceTree = "<group>"; };
+		DA4E4A41290AEC9800CF45E2 /* MonthlyStackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyStackViewModel.swift; sourceTree = "<group>"; };
+		DA4E4A43290AECE500CF45E2 /* MonthlyStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonthlyStackView.swift; sourceTree = "<group>"; };
 		DA91E7D528EABDED0091B6A3 /* Week.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Week.swift; sourceTree = "<group>"; };
 		DA91E7D728EB57AF0091B6A3 /* DateValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateValue.swift; sourceTree = "<group>"; };
 		DA91E7D928EB58310091B6A3 /* Extension+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+Date.swift"; sourceTree = "<group>"; };
@@ -278,6 +282,8 @@
 			isa = PBXGroup;
 			children = (
 				DA466EA128E685D70076AEE4 /* MonthlyView.swift */,
+				DA4E4A41290AEC9800CF45E2 /* MonthlyStackViewModel.swift */,
+				DA4E4A43290AECE500CF45E2 /* MonthlyStackView.swift */,
 				DA91E81328EDF38F0091B6A3 /* MonthlyViewModel.swift */,
 				DA91E7E428EC94170091B6A3 /* MonthlyCellView.swift */,
 				8647AFB928FD637F00EE1DA8 /* MonthlyCellViewModel.swift */,
@@ -580,6 +586,7 @@
 				DA91E81828EE01790091B6A3 /* HeaderViewModel.swift in Sources */,
 				DA2C798328F7268F00922C47 /* ReminderCreateAndEditViewModel.swift in Sources */,
 				DA3E9DAA2907810E00E72E21 /* ButtonStyle.swift in Sources */,
+				DA4E4A44290AECE500CF45E2 /* MonthlyStackView.swift in Sources */,
 				DA91E7E128EC8DFC0091B6A3 /* Event.swift in Sources */,
 				868C544128F417D9006A9B38 /* CustomTabBarView.swift in Sources */,
 				DA2C796628EF005B00922C47 /* NavigationRouter.swift in Sources */,
@@ -615,6 +622,7 @@
 				DA2C796328EEFFA300922C47 /* SceneDelegate.swift in Sources */,
 				86F0B2C528F6B969006E2536 /* WeeklyCellView.swift in Sources */,
 				86A5E60428EEA6B10040DCFB /* DayOfWeekStackViewModel.swift in Sources */,
+				DA4E4A42290AEC9800CF45E2 /* MonthlyStackViewModel.swift in Sources */,
 				86FC8CF528EAB3CF00B7752F /* DateHolder.swift in Sources */,
 				860F766628FCB98500CB034B /* CaledarViewModel.swift in Sources */,
 				86FC8CF828EAB42500B7752F /* WeeklyCalenderHelper.swift in Sources */,

--- a/checky/checky.xcodeproj/project.pbxproj
+++ b/checky/checky.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		DA4E4A46290C288600CF45E2 /* WeeklyStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A45290C288600CF45E2 /* WeeklyStackView.swift */; };
 		DA4E4A48290C289600CF45E2 /* WeeklyStackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A47290C289600CF45E2 /* WeeklyStackViewModel.swift */; };
 		DA4E4A4B290C74F800CF45E2 /* DailyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A4A290C74F800CF45E2 /* DailyView.swift */; };
+		DA4E4A4D290C78C700CF45E2 /* DailyCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A4C290C78C700CF45E2 /* DailyCellView.swift */; };
 		DA91E7D628EABDED0091B6A3 /* Week.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D528EABDED0091B6A3 /* Week.swift */; };
 		DA91E7D828EB57AF0091B6A3 /* DateValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D728EB57AF0091B6A3 /* DateValue.swift */; };
 		DA91E7DA28EB58310091B6A3 /* Extension+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D928EB58310091B6A3 /* Extension+Date.swift */; };
@@ -140,6 +141,7 @@
 		DA4E4A45290C288600CF45E2 /* WeeklyStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyStackView.swift; sourceTree = "<group>"; };
 		DA4E4A47290C289600CF45E2 /* WeeklyStackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyStackViewModel.swift; sourceTree = "<group>"; };
 		DA4E4A4A290C74F800CF45E2 /* DailyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyView.swift; sourceTree = "<group>"; };
+		DA4E4A4C290C78C700CF45E2 /* DailyCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyCellView.swift; sourceTree = "<group>"; };
 		DA91E7D528EABDED0091B6A3 /* Week.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Week.swift; sourceTree = "<group>"; };
 		DA91E7D728EB57AF0091B6A3 /* DateValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateValue.swift; sourceTree = "<group>"; };
 		DA91E7D928EB58310091B6A3 /* Extension+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+Date.swift"; sourceTree = "<group>"; };
@@ -440,6 +442,7 @@
 			isa = PBXGroup;
 			children = (
 				DA4E4A4A290C74F800CF45E2 /* DailyView.swift */,
+				DA4E4A4C290C78C700CF45E2 /* DailyCellView.swift */,
 			);
 			path = DailyView;
 			sourceTree = "<group>";
@@ -640,6 +643,7 @@
 				868C544328F417F7006A9B38 /* TabBarItem.swift in Sources */,
 				8647AFBA28FD637F00EE1DA8 /* MonthlyCellViewModel.swift in Sources */,
 				DA2C796328EEFFA300922C47 /* SceneDelegate.swift in Sources */,
+				DA4E4A4D290C78C700CF45E2 /* DailyCellView.swift in Sources */,
 				86F0B2C528F6B969006E2536 /* WeeklyCellView.swift in Sources */,
 				86A5E60428EEA6B10040DCFB /* DayOfWeekStackViewModel.swift in Sources */,
 				DA4E4A42290AEC9800CF45E2 /* MonthlyStackViewModel.swift in Sources */,

--- a/checky/checky.xcodeproj/project.pbxproj
+++ b/checky/checky.xcodeproj/project.pbxproj
@@ -60,7 +60,7 @@
 		DA4E4A4B290C74F800CF45E2 /* DailyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A4A290C74F800CF45E2 /* DailyView.swift */; };
 		DA4E4A4D290C78C700CF45E2 /* DailyCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A4C290C78C700CF45E2 /* DailyCellView.swift */; };
 		DA4E4A4F290C8ADB00CF45E2 /* DailyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A4E290C8ADA00CF45E2 /* DailyViewModel.swift */; };
-		DA78BC75290FC63F00E2E2AD /* DailyReminderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA78BC74290FC63F00E2E2AD /* DailyReminderCell.swift */; };
+		DA78BC75290FC63F00E2E2AD /* DailyReminderCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA78BC74290FC63F00E2E2AD /* DailyReminderCellView.swift */; };
 		DA78BC77290FE5E900E2E2AD /* DailyCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA78BC76290FE5E900E2E2AD /* DailyCellViewModel.swift */; };
 		DA78BC79290FE64800E2E2AD /* DailyReminderCellVeiwModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA78BC78290FE64800E2E2AD /* DailyReminderCellVeiwModel.swift */; };
 		DA91E7D628EABDED0091B6A3 /* Week.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D528EABDED0091B6A3 /* Week.swift */; };
@@ -149,7 +149,7 @@
 		DA4E4A4A290C74F800CF45E2 /* DailyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyView.swift; sourceTree = "<group>"; };
 		DA4E4A4C290C78C700CF45E2 /* DailyCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyCellView.swift; sourceTree = "<group>"; };
 		DA4E4A4E290C8ADA00CF45E2 /* DailyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyViewModel.swift; sourceTree = "<group>"; };
-		DA78BC74290FC63F00E2E2AD /* DailyReminderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyReminderCell.swift; sourceTree = "<group>"; };
+		DA78BC74290FC63F00E2E2AD /* DailyReminderCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyReminderCellView.swift; sourceTree = "<group>"; };
 		DA78BC76290FE5E900E2E2AD /* DailyCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyCellViewModel.swift; sourceTree = "<group>"; };
 		DA78BC78290FE64800E2E2AD /* DailyReminderCellVeiwModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyReminderCellVeiwModel.swift; sourceTree = "<group>"; };
 		DA91E7D528EABDED0091B6A3 /* Week.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Week.swift; sourceTree = "<group>"; };
@@ -456,7 +456,7 @@
 				DA4E4A4E290C8ADA00CF45E2 /* DailyViewModel.swift */,
 				DA4E4A4C290C78C700CF45E2 /* DailyCellView.swift */,
 				DA78BC76290FE5E900E2E2AD /* DailyCellViewModel.swift */,
-				DA78BC74290FC63F00E2E2AD /* DailyReminderCell.swift */,
+				DA78BC74290FC63F00E2E2AD /* DailyReminderCellView.swift */,
 				DA78BC78290FE64800E2E2AD /* DailyReminderCellVeiwModel.swift */,
 			);
 			path = DailyView;
@@ -624,7 +624,7 @@
 				DA4E4A46290C288600CF45E2 /* WeeklyStackView.swift in Sources */,
 				DA2C798328F7268F00922C47 /* ReminderCreateAndEditViewModel.swift in Sources */,
 				DA3E9DAA2907810E00E72E21 /* ButtonStyle.swift in Sources */,
-				DA78BC75290FC63F00E2E2AD /* DailyReminderCell.swift in Sources */,
+				DA78BC75290FC63F00E2E2AD /* DailyReminderCellView.swift in Sources */,
 				DA4E4A44290AECE500CF45E2 /* MonthlyStackView.swift in Sources */,
 				DA91E7E128EC8DFC0091B6A3 /* Event.swift in Sources */,
 				868C544128F417D9006A9B38 /* CustomTabBarView.swift in Sources */,

--- a/checky/checky.xcodeproj/project.pbxproj
+++ b/checky/checky.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		DA4E4A48290C289600CF45E2 /* WeeklyStackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A47290C289600CF45E2 /* WeeklyStackViewModel.swift */; };
 		DA4E4A4B290C74F800CF45E2 /* DailyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A4A290C74F800CF45E2 /* DailyView.swift */; };
 		DA4E4A4D290C78C700CF45E2 /* DailyCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A4C290C78C700CF45E2 /* DailyCellView.swift */; };
+		DA4E4A4F290C8ADB00CF45E2 /* DailyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A4E290C8ADA00CF45E2 /* DailyViewModel.swift */; };
 		DA91E7D628EABDED0091B6A3 /* Week.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D528EABDED0091B6A3 /* Week.swift */; };
 		DA91E7D828EB57AF0091B6A3 /* DateValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D728EB57AF0091B6A3 /* DateValue.swift */; };
 		DA91E7DA28EB58310091B6A3 /* Extension+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D928EB58310091B6A3 /* Extension+Date.swift */; };
@@ -142,6 +143,7 @@
 		DA4E4A47290C289600CF45E2 /* WeeklyStackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyStackViewModel.swift; sourceTree = "<group>"; };
 		DA4E4A4A290C74F800CF45E2 /* DailyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyView.swift; sourceTree = "<group>"; };
 		DA4E4A4C290C78C700CF45E2 /* DailyCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyCellView.swift; sourceTree = "<group>"; };
+		DA4E4A4E290C8ADA00CF45E2 /* DailyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyViewModel.swift; sourceTree = "<group>"; };
 		DA91E7D528EABDED0091B6A3 /* Week.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Week.swift; sourceTree = "<group>"; };
 		DA91E7D728EB57AF0091B6A3 /* DateValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateValue.swift; sourceTree = "<group>"; };
 		DA91E7D928EB58310091B6A3 /* Extension+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+Date.swift"; sourceTree = "<group>"; };
@@ -442,6 +444,7 @@
 			isa = PBXGroup;
 			children = (
 				DA4E4A4A290C74F800CF45E2 /* DailyView.swift */,
+				DA4E4A4E290C8ADA00CF45E2 /* DailyViewModel.swift */,
 				DA4E4A4C290C78C700CF45E2 /* DailyCellView.swift */,
 			);
 			path = DailyView;
@@ -602,6 +605,7 @@
 				868C543F28F417C0006A9B38 /* CustomTabBarContainerView.swift in Sources */,
 				865BE52628EC867900305899 /* WeekOption.swift in Sources */,
 				DA91E7E528EC94180091B6A3 /* MonthlyCellView.swift in Sources */,
+				DA4E4A4F290C8ADB00CF45E2 /* DailyViewModel.swift in Sources */,
 				DA3E9DAC29078FE200E72E21 /* Extension+Color.swift in Sources */,
 				DA91E81828EE01790091B6A3 /* HeaderViewModel.swift in Sources */,
 				DA4E4A46290C288600CF45E2 /* WeeklyStackView.swift in Sources */,
@@ -846,6 +850,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"checky/Preview Content\"";
+				DEVELOPMENT_TEAM = LZZV4V63N5;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = checky/Info.plist;
@@ -877,6 +882,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"checky/Preview Content\"";
+				DEVELOPMENT_TEAM = LZZV4V63N5;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = checky/Info.plist;

--- a/checky/checky.xcodeproj/project.pbxproj
+++ b/checky/checky.xcodeproj/project.pbxproj
@@ -59,6 +59,9 @@
 		DA4E4A4B290C74F800CF45E2 /* DailyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A4A290C74F800CF45E2 /* DailyView.swift */; };
 		DA4E4A4D290C78C700CF45E2 /* DailyCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A4C290C78C700CF45E2 /* DailyCellView.swift */; };
 		DA4E4A4F290C8ADB00CF45E2 /* DailyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4E4A4E290C8ADA00CF45E2 /* DailyViewModel.swift */; };
+		DA78BC75290FC63F00E2E2AD /* DailyReminderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA78BC74290FC63F00E2E2AD /* DailyReminderCell.swift */; };
+		DA78BC77290FE5E900E2E2AD /* DailyCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA78BC76290FE5E900E2E2AD /* DailyCellViewModel.swift */; };
+		DA78BC79290FE64800E2E2AD /* DailyReminderCellVeiwModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA78BC78290FE64800E2E2AD /* DailyReminderCellVeiwModel.swift */; };
 		DA91E7D628EABDED0091B6A3 /* Week.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D528EABDED0091B6A3 /* Week.swift */; };
 		DA91E7D828EB57AF0091B6A3 /* DateValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D728EB57AF0091B6A3 /* DateValue.swift */; };
 		DA91E7DA28EB58310091B6A3 /* Extension+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA91E7D928EB58310091B6A3 /* Extension+Date.swift */; };
@@ -144,6 +147,9 @@
 		DA4E4A4A290C74F800CF45E2 /* DailyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyView.swift; sourceTree = "<group>"; };
 		DA4E4A4C290C78C700CF45E2 /* DailyCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyCellView.swift; sourceTree = "<group>"; };
 		DA4E4A4E290C8ADA00CF45E2 /* DailyViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyViewModel.swift; sourceTree = "<group>"; };
+		DA78BC74290FC63F00E2E2AD /* DailyReminderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyReminderCell.swift; sourceTree = "<group>"; };
+		DA78BC76290FE5E900E2E2AD /* DailyCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyCellViewModel.swift; sourceTree = "<group>"; };
+		DA78BC78290FE64800E2E2AD /* DailyReminderCellVeiwModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyReminderCellVeiwModel.swift; sourceTree = "<group>"; };
 		DA91E7D528EABDED0091B6A3 /* Week.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Week.swift; sourceTree = "<group>"; };
 		DA91E7D728EB57AF0091B6A3 /* DateValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateValue.swift; sourceTree = "<group>"; };
 		DA91E7D928EB58310091B6A3 /* Extension+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+Date.swift"; sourceTree = "<group>"; };
@@ -446,6 +452,9 @@
 				DA4E4A4A290C74F800CF45E2 /* DailyView.swift */,
 				DA4E4A4E290C8ADA00CF45E2 /* DailyViewModel.swift */,
 				DA4E4A4C290C78C700CF45E2 /* DailyCellView.swift */,
+				DA78BC76290FE5E900E2E2AD /* DailyCellViewModel.swift */,
+				DA78BC74290FC63F00E2E2AD /* DailyReminderCell.swift */,
+				DA78BC78290FE64800E2E2AD /* DailyReminderCellVeiwModel.swift */,
 			);
 			path = DailyView;
 			sourceTree = "<group>";
@@ -611,6 +620,7 @@
 				DA4E4A46290C288600CF45E2 /* WeeklyStackView.swift in Sources */,
 				DA2C798328F7268F00922C47 /* ReminderCreateAndEditViewModel.swift in Sources */,
 				DA3E9DAA2907810E00E72E21 /* ButtonStyle.swift in Sources */,
+				DA78BC75290FC63F00E2E2AD /* DailyReminderCell.swift in Sources */,
 				DA4E4A44290AECE500CF45E2 /* MonthlyStackView.swift in Sources */,
 				DA91E7E128EC8DFC0091B6A3 /* Event.swift in Sources */,
 				868C544128F417D9006A9B38 /* CustomTabBarView.swift in Sources */,
@@ -636,6 +646,7 @@
 				DA2C797128F6E2C800922C47 /* Extension+View.swift in Sources */,
 				DA91E81428EDF3900091B6A3 /* MonthlyViewModel.swift in Sources */,
 				868C543D28F4178D006A9B38 /* TabBarItemsPreferenceKey.swift in Sources */,
+				DA78BC79290FE64800E2E2AD /* DailyReminderCellVeiwModel.swift in Sources */,
 				865BE52428EC4B6200305899 /* Extension+Text.swift in Sources */,
 				DA91E7E328EC8E580091B6A3 /* Reminder.swift in Sources */,
 				DA2C796A28EF009800922C47 /* Coordinator.swift in Sources */,
@@ -654,6 +665,7 @@
 				86FC8CF528EAB3CF00B7752F /* DateHolder.swift in Sources */,
 				860F766628FCB98500CB034B /* CaledarViewModel.swift in Sources */,
 				86FC8CF828EAB42500B7752F /* WeeklyCalenderHelper.swift in Sources */,
+				DA78BC77290FE5E900E2E2AD /* DailyCellViewModel.swift in Sources */,
 				DA91E7DA28EB58310091B6A3 /* Extension+Date.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/checky/checky/CalenderData/MonthlyCalendarHelper.swift
+++ b/checky/checky/CalenderData/MonthlyCalendarHelper.swift
@@ -61,4 +61,28 @@ struct MonthyCalendarHelper: CalendarCanDo {
     
     return currentMonth.getAllDates().map { DateValue(date: $0, isCurrentMonth: true) }
   }
+  
+  func extractPastCurrentFutureDates(_ date: Date) -> [Date] {
+    var dates: [Date] = []
+    
+    guard let currentMonth = calendar.date(byAdding: .month, value: 0, to: date) else {
+      return []
+    }
+    
+    guard let preMonth = calendar.date(byAdding: .month, value: -1, to: date) else {
+      return []
+    }
+    
+    guard let nextMonth = calendar.date(byAdding: .month, value: 1, to: date) else {
+      return []
+    }
+    
+    dates.append(preMonth)
+    dates.append(currentMonth)
+    dates.append(nextMonth)
+    
+    print(dates)
+    
+    return dates
+  }
 }

--- a/checky/checky/CalenderData/MonthlyCalendarHelper.swift
+++ b/checky/checky/CalenderData/MonthlyCalendarHelper.swift
@@ -36,25 +36,10 @@ struct MonthyCalendarHelper: CalendarCanDo {
   }
   
   func extractDates(_ date: Date) -> [DateValue] {
-    var currentCalendar: [DateValue] = []
-    
-    let days = saveDaysOfCurrentMonth(date)
-    
-    guard let firstDayOfMonth = days.first, let lastDayOfMonth = days.last else {
-      return []
-    }
-    
-    let previousDays = previousDates(currentday: firstDayOfMonth)
-    let nextDays = nextDates(currentday: lastDayOfMonth)
-    
-    previousDays.forEach { currentCalendar.append($0) }
-    days.forEach { currentCalendar.append($0) }
-    nextDays.forEach{ currentCalendar.append($0) }
-    
-    return currentCalendar
+    extractMonthDates(date)
   }
   
-  func saveDaysOfCurrentMonth(_ date: Date) -> [DateValue] {
+  private func saveDaysOfCurrentMonth(_ date: Date) -> [DateValue] {
     guard let currentMonth = calendar.date(byAdding: .month, value: 0, to: date) else {
       return []
     }

--- a/checky/checky/CalenderData/WeeklyCalenderHelper.swift
+++ b/checky/checky/CalenderData/WeeklyCalenderHelper.swift
@@ -57,6 +57,27 @@ struct WeeklyCalendarHelper: CalendarCanDo {
   }
   
   func extractPastCurrentFutureDates(_ date: Date) -> [Date] {
-    return []
+    // 앞주를 구하기...
+    var dates: [Date] = []
+    
+    guard let currentMonth = calendar.date(byAdding: .day, value: 0, to: date) else {
+      return []
+    }
+    
+    guard let preMonth = calendar.date(byAdding: .day, value: -7, to: date) else {
+      return []
+    }
+    
+    guard let nextMonth = calendar.date(byAdding: .day, value: 7, to: date) else {
+      return []
+    }
+    
+    dates.append(preMonth)
+    dates.append(currentMonth)
+    dates.append(nextMonth)
+    
+    print(dates)
+    
+    return dates
   }
 }

--- a/checky/checky/CalenderData/WeeklyCalenderHelper.swift
+++ b/checky/checky/CalenderData/WeeklyCalenderHelper.swift
@@ -57,7 +57,6 @@ struct WeeklyCalendarHelper: CalendarCanDo {
   }
   
   func extractPastCurrentFutureDates(_ date: Date) -> [Date] {
-    // 앞주를 구하기...
     var dates: [Date] = []
     
     guard let currentMonth = calendar.date(byAdding: .day, value: 0, to: date) else {

--- a/checky/checky/CalenderData/WeeklyCalenderHelper.swift
+++ b/checky/checky/CalenderData/WeeklyCalenderHelper.swift
@@ -55,4 +55,8 @@ struct WeeklyCalendarHelper: CalendarCanDo {
     
     return currentWeek
   }
+  
+  func extractPastCurrentFutureDates(_ date: Date) -> [Date] {
+    return []
+  }
 }

--- a/checky/checky/CalenderData/WeeklyCalenderHelper.swift
+++ b/checky/checky/CalenderData/WeeklyCalenderHelper.swift
@@ -63,13 +63,8 @@ struct WeeklyCalendarHelper: CalendarCanDo {
       return []
     }
     
-    guard let preMonth = calendar.date(byAdding: .day, value: -7, to: date) else {
-      return []
-    }
-    
-    guard let nextMonth = calendar.date(byAdding: .day, value: 7, to: date) else {
-      return []
-    }
+    let preMonth = plusDate(date)
+    let nextMonth = minusDate(date)
     
     dates.append(preMonth)
     dates.append(currentMonth)

--- a/checky/checky/Coordinator/CheckyRouter.swift
+++ b/checky/checky/Coordinator/CheckyRouter.swift
@@ -14,7 +14,8 @@ enum checkyRouter: NavigationRouter {
   case create
   case createEvent
   case createReminder
-  case daily([Event], [Reminder], [Reminder], ReminderManager)
+  case daily([Event], [Reminder], [Reminder], EventManager, ReminderManager)
+  case editEvent(Event, EventManager)
   
   var transition: NavigationTranisitionStyle {
     switch self {
@@ -27,6 +28,8 @@ enum checkyRouter: NavigationRouter {
       case .createReminder:
         return .presentModally
       case .daily:
+        return .presentModally
+      case .editEvent:
         return .presentModally
     }
   }
@@ -42,8 +45,11 @@ enum checkyRouter: NavigationRouter {
         EventCreateAndEditView(viewModel: EventCreateAndEditViewModel(mode: .create, eventManager: EventManager()))
       case .createReminder:
         ReminderCreateAndEditView(viewModel: ReminderCreateAndEditViewModel(mode: .create, reminderManager: ReminderManager()))
-      case .daily(let events, let reminders, let clearedReminders, let reminderManager):
-        DailyView(viewModel: DailyViewModel(events: events, reminders: reminders, clearedReminders: clearedReminders, eventManager: EventManager(), reminderManager: reminderManager))
+      case .daily(let events, let reminders, let clearedReminders, let eventManager, let reminderManager):
+        DailyView(viewModel: DailyViewModel(events: events, reminders: reminders, clearedReminders: clearedReminders, eventManager: eventManager, reminderManager: reminderManager))
+      case .editEvent(let event, let eventManager):
+        EventCreateAndEditView(viewModel: EventCreateAndEditViewModel(event: event, eventManager: eventManager))
+        
     }
   }
 }

--- a/checky/checky/Coordinator/CheckyRouter.swift
+++ b/checky/checky/Coordinator/CheckyRouter.swift
@@ -14,7 +14,7 @@ enum checkyRouter: NavigationRouter {
   case create
   case createEvent
   case createReminder
-  case daily([Event])
+  case daily([Event], [Reminder], ReminderManager)
   
   var transition: NavigationTranisitionStyle {
     switch self {
@@ -42,8 +42,8 @@ enum checkyRouter: NavigationRouter {
         EventCreateAndEditView(viewModel: EventCreateAndEditViewModel(mode: .create, eventManager: EventManager()))
       case .createReminder:
         ReminderCreateAndEditView(viewModel: ReminderCreateAndEditViewModel(mode: .create, reminderManager: ReminderManager()))
-      case .daily(let events):
-        DailyView(events: events)
+      case .daily(let events, let reminders, let reminderManager):
+        DailyView(viewModel: DailyViewModel(events: events, reminders: reminders, eventManager: EventManager(), reminderManager: reminderManager))
     }
   }
 }

--- a/checky/checky/Coordinator/CheckyRouter.swift
+++ b/checky/checky/Coordinator/CheckyRouter.swift
@@ -9,10 +9,12 @@ import SwiftUI
 
 enum checkyRouter: NavigationRouter {
   
+  
   case main
   case create
   case createEvent
   case createReminder
+  case daily([Event])
   
   var transition: NavigationTranisitionStyle {
     switch self {
@@ -24,6 +26,8 @@ enum checkyRouter: NavigationRouter {
         return .presentModally
       case .createReminder:
         return .presentModally
+      case .daily:
+        return .presentModally
     }
   }
   
@@ -34,12 +38,12 @@ enum checkyRouter: NavigationRouter {
         checkyApp()
       case .create:
         CreateSelectorView()
-        //        EventCreateAndEditView(viewModel: EventCreateAndEditViewModel(mode: .create))
-        //      ReminderCreateAndEditView(viewModel: ReminderCreateAndEditViewModel(mode: .create))
       case .createEvent:
         EventCreateAndEditView(viewModel: EventCreateAndEditViewModel(mode: .create, eventManager: EventManager()))
       case .createReminder:
         ReminderCreateAndEditView(viewModel: ReminderCreateAndEditViewModel(mode: .create, reminderManager: ReminderManager()))
+      case .daily(let events):
+        DailyView(events: events)
     }
   }
 }

--- a/checky/checky/Coordinator/CheckyRouter.swift
+++ b/checky/checky/Coordinator/CheckyRouter.swift
@@ -14,7 +14,7 @@ enum checkyRouter: NavigationRouter {
   case create
   case createEvent
   case createReminder
-  case daily([Event], [Reminder], ReminderManager)
+  case daily([Event], [Reminder], [Reminder], ReminderManager)
   
   var transition: NavigationTranisitionStyle {
     switch self {
@@ -42,8 +42,8 @@ enum checkyRouter: NavigationRouter {
         EventCreateAndEditView(viewModel: EventCreateAndEditViewModel(mode: .create, eventManager: EventManager()))
       case .createReminder:
         ReminderCreateAndEditView(viewModel: ReminderCreateAndEditViewModel(mode: .create, reminderManager: ReminderManager()))
-      case .daily(let events, let reminders, let reminderManager):
-        DailyView(viewModel: DailyViewModel(events: events, reminders: reminders, eventManager: EventManager(), reminderManager: reminderManager))
+      case .daily(let events, let reminders, let clearedReminders, let reminderManager):
+        DailyView(viewModel: DailyViewModel(events: events, reminders: reminders, clearedReminders: clearedReminders, eventManager: EventManager(), reminderManager: reminderManager))
     }
   }
 }

--- a/checky/checky/Coordinator/CheckyRouter.swift
+++ b/checky/checky/Coordinator/CheckyRouter.swift
@@ -48,11 +48,11 @@ enum checkyRouter: NavigationRouter {
         EventCreateAndEditView(viewModel: EventCreateAndEditViewModel(mode: .create, eventManager: EventManager()))
       case .createReminder:
         ReminderCreateAndEditView(viewModel: ReminderCreateAndEditViewModel(mode: .create, reminderManager: ReminderManager()))
-      case .daily(let date, let events, let reminders, let clearedReminders, let eventManager, let reminderManager):
+      case let .daily(date, events, reminders, clearedReminders, eventManager, reminderManager):
         DailyView(viewModel: DailyViewModel(date: date, events: events, reminders: reminders, clearedReminders: clearedReminders, eventManager: eventManager, reminderManager: reminderManager))
-      case .editEvent(let event, let eventManager):
+      case let .editEvent(event, eventManager):
         EventCreateAndEditView(viewModel: EventCreateAndEditViewModel(event: event, eventManager: eventManager))
-      case .editReminder(let reminder, let reminderManager):
+      case let .editReminder(reminder, reminderManager):
         ReminderCreateAndEditView(viewModel: ReminderCreateAndEditViewModel(reminder: reminder, reminderManager: reminderManager))
         
     }

--- a/checky/checky/Coordinator/CheckyRouter.swift
+++ b/checky/checky/Coordinator/CheckyRouter.swift
@@ -29,7 +29,7 @@ enum checkyRouter: NavigationRouter {
       case .createReminder:
         return .presentModally
       case .daily:
-        return .presentModally
+        return .push
       case .editEvent:
         return .presentModally
       case .editReminder:

--- a/checky/checky/Coordinator/CheckyRouter.swift
+++ b/checky/checky/Coordinator/CheckyRouter.swift
@@ -14,7 +14,7 @@ enum checkyRouter: NavigationRouter {
   case create
   case createEvent
   case createReminder
-  case daily([Event], [Reminder], [Reminder], EventManager, ReminderManager)
+  case daily(Date, [Event], [Reminder], [Reminder], EventManager, ReminderManager)
   case editEvent(Event, EventManager)
   
   var transition: NavigationTranisitionStyle {
@@ -45,8 +45,8 @@ enum checkyRouter: NavigationRouter {
         EventCreateAndEditView(viewModel: EventCreateAndEditViewModel(mode: .create, eventManager: EventManager()))
       case .createReminder:
         ReminderCreateAndEditView(viewModel: ReminderCreateAndEditViewModel(mode: .create, reminderManager: ReminderManager()))
-      case .daily(let events, let reminders, let clearedReminders, let eventManager, let reminderManager):
-        DailyView(viewModel: DailyViewModel(events: events, reminders: reminders, clearedReminders: clearedReminders, eventManager: eventManager, reminderManager: reminderManager))
+      case .daily(let date, let events, let reminders, let clearedReminders, let eventManager, let reminderManager):
+        DailyView(viewModel: DailyViewModel(date: date, events: events, reminders: reminders, clearedReminders: clearedReminders, eventManager: eventManager, reminderManager: reminderManager))
       case .editEvent(let event, let eventManager):
         EventCreateAndEditView(viewModel: EventCreateAndEditViewModel(event: event, eventManager: eventManager))
         

--- a/checky/checky/Coordinator/CheckyRouter.swift
+++ b/checky/checky/Coordinator/CheckyRouter.swift
@@ -8,8 +8,6 @@
 import SwiftUI
 
 enum checkyRouter: NavigationRouter {
-  
-  
   case main
   case create
   case createEvent
@@ -54,7 +52,6 @@ enum checkyRouter: NavigationRouter {
         EventCreateAndEditView(viewModel: EventCreateAndEditViewModel(event: event, eventManager: eventManager))
       case let .editReminder(reminder, reminderManager):
         ReminderCreateAndEditView(viewModel: ReminderCreateAndEditViewModel(reminder: reminder, reminderManager: reminderManager))
-        
     }
   }
 }

--- a/checky/checky/Coordinator/CheckyRouter.swift
+++ b/checky/checky/Coordinator/CheckyRouter.swift
@@ -16,6 +16,7 @@ enum checkyRouter: NavigationRouter {
   case createReminder
   case daily(Date, [Event], [Reminder], [Reminder], EventManager, ReminderManager)
   case editEvent(Event, EventManager)
+  case editReminder(Reminder, ReminderManager)
   
   var transition: NavigationTranisitionStyle {
     switch self {
@@ -30,6 +31,8 @@ enum checkyRouter: NavigationRouter {
       case .daily:
         return .presentModally
       case .editEvent:
+        return .presentModally
+      case .editReminder:
         return .presentModally
     }
   }
@@ -49,6 +52,8 @@ enum checkyRouter: NavigationRouter {
         DailyView(viewModel: DailyViewModel(date: date, events: events, reminders: reminders, clearedReminders: clearedReminders, eventManager: eventManager, reminderManager: reminderManager))
       case .editEvent(let event, let eventManager):
         EventCreateAndEditView(viewModel: EventCreateAndEditViewModel(event: event, eventManager: eventManager))
+      case .editReminder(let reminder, let reminderManager):
+        ReminderCreateAndEditView(viewModel: ReminderCreateAndEditViewModel(reminder: reminder, reminderManager: reminderManager))
         
     }
   }

--- a/checky/checky/Coordinator/Coordinator.swift
+++ b/checky/checky/Coordinator/Coordinator.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 class Coordinator<Router: NavigationRouter>: ObservableObject {
-  
   let navigationController: UINavigationController
   let startingRoute: Router?
   

--- a/checky/checky/Coordinator/Coordinator.swift
+++ b/checky/checky/Coordinator/Coordinator.swift
@@ -29,6 +29,7 @@ class Coordinator<Router: NavigationRouter>: ObservableObject {
     switch route.transition {
     case .push:
       navigationController.pushViewController(viewController, animated: animated)
+        navigationController.navigationBar.isHidden = true
     case .presentModally:
       viewController.modalPresentationStyle = .formSheet
       navigationController.present(viewController, animated: animated)

--- a/checky/checky/Coordinator/Coordinator.swift
+++ b/checky/checky/Coordinator/Coordinator.swift
@@ -28,7 +28,6 @@ class Coordinator<Router: NavigationRouter>: ObservableObject {
     switch route.transition {
     case .push:
       navigationController.pushViewController(viewController, animated: animated)
-        navigationController.navigationBar.isHidden = true
     case .presentModally:
       viewController.modalPresentationStyle = .formSheet
       navigationController.present(viewController, animated: animated)

--- a/checky/checky/EventKitManager/EventManager.swift
+++ b/checky/checky/EventKitManager/EventManager.swift
@@ -71,6 +71,17 @@ struct EventManager: ManagerProtocol {
     }
   }
   
+  func editTask(task: EKCalendarItem) {
+    guard let task = task as? EKEvent else { return }
+    
+    do {
+      try store.save(task, span: EKSpan.futureEvents, commit: true)
+    } catch {
+      print("event 저장 실패🥲")
+      print(error.localizedDescription)
+    }
+  }
+  
   func getTaskCategories() -> [EKCalendar] {
     return store.calendars(for: .event)
   }

--- a/checky/checky/EventKitManager/EventManager.swift
+++ b/checky/checky/EventKitManager/EventManager.swift
@@ -35,9 +35,9 @@ struct EventManager: ManagerProtocol {
   }
   
   func filterTask(_ target: [Event], _ date: Date) -> [Event] {
-    target
-      .filter { $0.ekevent.startDate.compare(date) != ComparisonResult.orderedDescending &&
-        $0.ekevent.endDate.compare(date) != ComparisonResult.orderedAscending }
+    return target.filter { event in
+      return event.ekevent.startDate.compareWithoutTime(date) || event.ekevent.endDate.compareWithoutTime(date)
+    }
   }
   
   func getAllTaskforThisMonth(date: Date, completionHandler: @escaping ([Event]) -> Void) {

--- a/checky/checky/EventKitManager/EventManager.swift
+++ b/checky/checky/EventKitManager/EventManager.swift
@@ -51,7 +51,7 @@ struct EventManager: ManagerProtocol {
     var list: [Event] = []
     
     for category in categories {
-      let predicate = store.predicateForEvents(withStart: firstDate, end: lastDate, calendars: [category])
+      let predicate = store.predicateForEvents(withStart: firstDate.minusSevenDates, end: lastDate.plusSevenDates, calendars: [category])
       let eventList = store.events(matching: predicate).map { ekevent -> Event in
         return Event(ekevent: ekevent, category: category)
       }

--- a/checky/checky/EventKitManager/ReminderManager.swift
+++ b/checky/checky/EventKitManager/ReminderManager.swift
@@ -42,6 +42,12 @@ struct ReminderManager: ManagerProtocol {
         $0.ekreminder.dueDateComponents?.month == calendar.dateComponents([.month], from: date).month }
   }
   
+  func filterClearTask(_ taget: [Reminder], _ date: Date) -> [Reminder] {
+    taget
+      .filter { $0.ekreminder.completionDate != nil }
+      .filter { $0.ekreminder.completionDate?.day == date.day }
+  }
+    
   func getAllTaskforThisMonth(date: Date, completionHandler: @escaping ([Reminder]) -> Void) {
     let categories = store.calendars(for: .reminder)
     
@@ -59,22 +65,22 @@ struct ReminderManager: ManagerProtocol {
       }
     }
   }
-
-  func createNewTask(newTask: EKCalendarItem) {
-    guard let newTask = newTask as? EKReminder else { return }
     
-    do {
-      try store.save(newTask, commit: true)
-    } catch {
-      print("reminder 저장 실패🥲")
-      print(error.localizedDescription)
+  func createNewTask(newTask: EKCalendarItem) {
+      guard let newTask = newTask as? EKReminder else { return }
+      
+      do {
+        try store.save(newTask, commit: true)
+      } catch {
+        print("reminder 저장 실패🥲")
+        print(error.localizedDescription)
+      }
     }
-  }
-  
+    
   func getTaskCategories() -> [EKCalendar] {
-    return store.calendars(for: .reminder)
-  }
-  
+      return store.calendars(for: .reminder)
+    }
+    
   func editReminder(_ reminder: EKReminder) -> Result<Bool, Error> {
     do {
       try store.save(reminder, commit: true)
@@ -84,7 +90,7 @@ struct ReminderManager: ManagerProtocol {
       return .failure(error)
     }
   }
-}
+  }
 
 
 extension EKCalendar: Identifiable {}

--- a/checky/checky/EventKitManager/ReminderManager.swift
+++ b/checky/checky/EventKitManager/ReminderManager.swift
@@ -39,13 +39,18 @@ struct ReminderManager: ManagerProtocol {
     taget
       .filter {
         $0.ekreminder.dueDateComponents?.day == calendar.dateComponents([.day], from: date).day &&
-        $0.ekreminder.dueDateComponents?.month == calendar.dateComponents([.month], from: date).month }
+        $0.ekreminder.dueDateComponents?.month == calendar.dateComponents([.month], from: date).month && $0.ekreminder.dueDateComponents?.year == calendar.dateComponents([.year], from: date).year}
+  }
+  
+  func filterHighPriorityTask(_ taget: [Reminder], _ date: Date) -> [Reminder] {
+    taget
+      .filter { $0.ekreminder.priority == 1 }
   }
   
   func filterClearTask(_ taget: [Reminder], _ date: Date) -> [Reminder] {
     taget
       .filter { $0.ekreminder.completionDate != nil }
-      .filter { $0.ekreminder.completionDate?.day == date.day }
+      .filter { $0.ekreminder.completionDate?.day == date.day && $0.ekreminder.completionDate?.month == date.month && $0.ekreminder.completionDate?.year == date.year }
   }
     
   func getAllTaskforThisMonth(date: Date, completionHandler: @escaping ([Reminder]) -> Void) {

--- a/checky/checky/EventKitManager/ReminderManager.swift
+++ b/checky/checky/EventKitManager/ReminderManager.swift
@@ -74,6 +74,16 @@ struct ReminderManager: ManagerProtocol {
   func getTaskCategories() -> [EKCalendar] {
     return store.calendars(for: .reminder)
   }
+  
+  func editReminder(_ reminder: EKReminder) -> Result<Bool, Error> {
+    do {
+      try store.save(reminder, commit: true)
+      return .success(reminder.isCompleted)
+    } catch {
+      print("reminder 저장 실패🥲")
+      return .failure(error)
+    }
+  }
 }
 
 

--- a/checky/checky/Extension/Extension+Date.swift
+++ b/checky/checky/Extension/Extension+Date.swift
@@ -82,4 +82,22 @@ extension Date {
     dateformmater.dateFormat = "yyyy년 M월 d일"
     return dateformmater.string(from: self) == dateformmater.string(from: date)
   }
+  
+  var minusSevenDates: Date {
+    let calendar = Calendar(identifier: .gregorian)
+    
+    guard let previousWeek = calendar.date(byAdding: .day, value: -7, to: self) else {
+      return Date()
+    }
+    return previousWeek
+  }
+  
+  var plusSevenDates: Date {
+    let calendar = Calendar(identifier: .gregorian)
+
+    guard let nextWeek = calendar.date(byAdding: .day, value: 7, to: self) else {
+      return Date()
+    }
+    return nextWeek
+  }
 }

--- a/checky/checky/Extension/Extension+Date.swift
+++ b/checky/checky/Extension/Extension+Date.swift
@@ -33,6 +33,13 @@ extension Date {
     return dateformmater.string(from: self)
   }
   
+  var month: String {
+    let dateformmater = DateFormatter()
+    dateformmater.locale = Locale(identifier: "ko_KR")
+    dateformmater.dateFormat = "M"
+    return dateformmater.string(from: self)
+  }
+  
   var dayOfWeek: String {
     let formatter = DateFormatter()
     formatter.dateFormat = "EEE"

--- a/checky/checky/Extension/Extension+Date.swift
+++ b/checky/checky/Extension/Extension+Date.swift
@@ -40,6 +40,13 @@ extension Date {
     return dateformmater.string(from: self)
   }
   
+  var year: String {
+    let dateformmater = DateFormatter()
+    dateformmater.locale = Locale(identifier: "ko_KR")
+    dateformmater.dateFormat = "yyyy"
+    return dateformmater.string(from: self)
+  }
+  
   var dayOfWeek: String {
     let formatter = DateFormatter()
     formatter.dateFormat = "EEE"

--- a/checky/checky/Extension/Extension+Date.swift
+++ b/checky/checky/Extension/Extension+Date.swift
@@ -61,4 +61,11 @@ extension Date {
     dateformmater.dateFormat = "a hh : mm "
     return dateformmater.string(from: self)
   }
+  
+  func compareWithoutTime(_ date: Date) -> Bool {
+    let dateformmater = DateFormatter()
+    dateformmater.locale = Locale(identifier: "ko_KR")
+    dateformmater.dateFormat = "yyyy년 M월 d일"
+    return dateformmater.string(from: self) == dateformmater.string(from: date)
+  }
 }

--- a/checky/checky/Extension/Extension+Text.swift
+++ b/checky/checky/Extension/Extension+Text.swift
@@ -10,7 +10,8 @@ import SwiftUI
 extension Text {
   func weekStyle() -> some View {
     self.frame(maxWidth: .infinity)
-      .foregroundColor(Color("fontMediumGray"))
+      .font(.caption2)
+      .foregroundColor(Color.fontMediumGray)
       .padding(.top)
       .lineLimit(1)
   }

--- a/checky/checky/Extension/Extension+Text.swift
+++ b/checky/checky/Extension/Extension+Text.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 extension Text {
   func weekStyle() -> some View {
-    self.frame(maxWidth: .infinity)
+    self
+      .frame(maxWidth: .infinity)
       .font(.caption2)
       .foregroundColor(Color.fontMediumGray)
       .padding(.top)

--- a/checky/checky/Protocol/CalendarCanDoProtocol.swift
+++ b/checky/checky/Protocol/CalendarCanDoProtocol.swift
@@ -15,6 +15,7 @@ protocol CalendarCanDo {
   func plusDate(_ date: Date) -> Date
   func minusDate(_ date: Date) -> Date
   func extractDates(_ date: Date) -> [DateValue]
+  func extractPastCurrentFutureDates(_ date: Date) -> [Date]
 }
 
 extension CalendarCanDo {

--- a/checky/checky/Protocol/CalendarCanDoProtocol.swift
+++ b/checky/checky/Protocol/CalendarCanDoProtocol.swift
@@ -86,4 +86,31 @@ extension CalendarCanDo {
     
     return 6 - lastWeekday.rawValue + startingWeek.rawValue
   }
+  
+  func extractMonthDates(_ date: Date) -> [DateValue] {
+    var currentCalendar: [DateValue] = []
+    
+    let days = saveDaysOfCurrentMonth(date)
+    
+    guard let firstDayOfMonth = days.first, let lastDayOfMonth = days.last else {
+      return []
+    }
+    
+    let previousDays = previousDates(currentday: firstDayOfMonth)
+    let nextDays = nextDates(currentday: lastDayOfMonth)
+    
+    previousDays.forEach { currentCalendar.append($0) }
+    days.forEach { currentCalendar.append($0) }
+    nextDays.forEach{ currentCalendar.append($0) }
+    
+    return currentCalendar
+  }
+  
+  private func saveDaysOfCurrentMonth(_ date: Date) -> [DateValue] {
+    guard let currentMonth = calendar.date(byAdding: .month, value: 0, to: date) else {
+      return []
+    }
+    
+    return currentMonth.getAllDates().map { DateValue(date: $0, isCurrentMonth: true) }
+  }
 }

--- a/checky/checky/Protocol/CalendarCanDoProtocol.swift
+++ b/checky/checky/Protocol/CalendarCanDoProtocol.swift
@@ -25,6 +25,12 @@ extension CalendarCanDo {
     return dataFormatter.string(from: date)
   }
   
+  func monthYearDayString(_ date: Date) -> String {
+    let dataFormatter = DateFormatter()
+    dataFormatter.dateFormat = "YYYY MM dd"
+    return dataFormatter.string(from: date)
+  }
+  
   func previousDates(currentday: DateValue) -> [DateValue] {
     var previousDays: [DateValue] = []
     let previousMonthDayCount = savePreviousDateCount(targetDate: currentday)

--- a/checky/checky/Utils/ButtonStyle.swift
+++ b/checky/checky/Utils/ButtonStyle.swift
@@ -21,7 +21,6 @@ struct ToggleButtonStyle: ButtonStyle {
 }
 
 struct CreateButtonStyle: ButtonStyle {
-  
   func makeBody(configuration: Self.Configuration) -> some View {
     ZStack {
       RoundedRectangle(cornerRadius: 8)

--- a/checky/checky/View/CreateSelectorView.swift
+++ b/checky/checky/View/CreateSelectorView.swift
@@ -58,9 +58,3 @@ struct CreateSelectorView: View {
     }
   }
 }
-
-struct CreateSelectorView_Previews: PreviewProvider {
-  static var previews: some View {
-    CreateSelectorView()
-  }
-}

--- a/checky/checky/View/EventCreateView/AlramTime.swift
+++ b/checky/checky/View/EventCreateView/AlramTime.swift
@@ -7,18 +7,18 @@
 
 import Foundation
 
-enum AlramTime: CaseIterable {
-  case none
-  case onTime
-  case fiveMinute
-  case tenMinute
-  case fifteenMinute
-  case thirtyMinute
-  case oneHour
-  case twoHours
-  case oneDay
-  case twoDays
-  case oneWeek
+enum AlramTime: Double, CaseIterable {
+  case none = -1
+  case onTime = 0
+  case fiveMinute = -300
+  case tenMinute = -600
+  case fifteenMinute = -900
+  case thirtyMinute = -1800
+  case oneHour = -3600
+  case twoHours = -7200
+  case oneDay = -86400
+  case twoDays = -172800
+  case oneWeek = -604800
   
   var korean: String {
     switch self {

--- a/checky/checky/View/EventCreateView/EventCreateAndEditView.swift
+++ b/checky/checky/View/EventCreateView/EventCreateAndEditView.swift
@@ -9,7 +9,11 @@ import SwiftUI
 import EventKit
 
 struct EventCreateAndEditView: View {
-  @ObservedObject var viewModel = EventCreateAndEditViewModel(mode: .edit, eventManager: EventManager())
+  @ObservedObject var viewModel: EventCreateAndEditViewModel
+  
+  init(viewModel: EventCreateAndEditViewModel) {
+    self.viewModel = viewModel
+  }
   
   var body: some View {
     VStack {

--- a/checky/checky/View/EventCreateView/EventCreateAndEditViewModel.swift
+++ b/checky/checky/View/EventCreateView/EventCreateAndEditViewModel.swift
@@ -192,7 +192,6 @@ class EventCreateAndEditViewModel: ObservableObject {
     if mode == .create {
       createEvent()
     } else {
-      // 이벤트 수정
       editEvent()
     }
     closeAllPickers()

--- a/checky/checky/View/MainView/CalendarView/CaledarViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/CaledarViewModel.swift
@@ -10,5 +10,4 @@ import Combine
 
 class CalendarViewModel: ObservableObject {
   @Published var mode: Bool = true
-  
 }

--- a/checky/checky/View/MainView/CalendarView/CalendarView.swift
+++ b/checky/checky/View/MainView/CalendarView/CalendarView.swift
@@ -16,16 +16,21 @@ struct CalendarView: View {
   var reminderManager: ReminderManager = ReminderManager()
   
   var body: some View {
-    
-    if viewModel.mode {
-      WeeklyStackView(viewModel: WeeklyStackViewModel(dateHolder: DateHolder(), eventManager: eventManager, reminderManager: reminderManager, calendarHelper: WeeklyCalendarHelper(), offsetWidth: UIScreen.main.bounds.width, moveToMonthly: { viewModel.mode.toggle() } ))
+    Group {
+      if viewModel.mode {
+        WeeklyStackView(viewModel: WeeklyStackViewModel(dateHolder: DateHolder(), eventManager: eventManager, reminderManager: reminderManager, calendarHelper: WeeklyCalendarHelper(), offsetWidth: UIScreen.main.bounds.width, moveToMonthly: { viewModel.mode.toggle() } ))
+          .environmentObject(coordinator)
+        
+      } else {
+        MonthlyStackView(viewModel:  MonthlyStackViewModel(dateHolder: DateHolder(), eventManager: eventManager, reminderManager: reminderManager, calendarHelper: MonthyCalendarHelper(), offsetWidth: UIScreen.main.bounds.width, moveToWeek: {
+          viewModel.mode.toggle()
+        }))
         .environmentObject(coordinator)
-
-    } else {
-      MonthlyStackView(viewModel:  MonthlyStackViewModel(dateHolder: DateHolder(), eventManager: eventManager, reminderManager: reminderManager, calendarHelper: MonthyCalendarHelper(), offsetWidth: UIScreen.main.bounds.width, moveToWeek: {
-        viewModel.mode.toggle()
-      }))
-      .environmentObject(coordinator)
+      }
+    }
+    .onAppear {
+      eventManager.getPermission()
+      reminderManager.getPermission()
     }
   }
 }

--- a/checky/checky/View/MainView/CalendarView/CalendarView.swift
+++ b/checky/checky/View/MainView/CalendarView/CalendarView.swift
@@ -12,6 +12,7 @@ import EventKit
 struct CalendarView: View {
   @EnvironmentObject var coordinator: Coordinator<checkyRouter>
   @StateObject var viewModel: CalendarViewModel = CalendarViewModel()
+  
   var eventManager: EventManager = EventManager()
   var reminderManager: ReminderManager = ReminderManager()
   

--- a/checky/checky/View/MainView/CalendarView/CalendarView.swift
+++ b/checky/checky/View/MainView/CalendarView/CalendarView.swift
@@ -9,17 +9,20 @@ import SwiftUI
 import Combine
 
 struct CalendarView: View {
+  @EnvironmentObject var coordinator: Coordinator<checkyRouter>
   @StateObject var viewModel: CalendarViewModel = CalendarViewModel()
   
   var body: some View {
     
     if viewModel.mode {
       WeeklyStackView(viewModel: WeeklyStackViewModel(dateHolder: DateHolder(), eventManager: EventManager(), reminderManager: ReminderManager(), calendarHelper: WeeklyCalendarHelper(), offsetWidth: UIScreen.main.bounds.width, moveToMonthly: { viewModel.mode.toggle() } ))
+        .environmentObject(coordinator)
 
     } else {
       MonthlyStackView(viewModel:  MonthlyStackViewModel(dateHolder: DateHolder(), eventManager: EventManager(), reminderManager: ReminderManager(), calendarHelper: MonthyCalendarHelper(), offsetWidth: UIScreen.main.bounds.width, moveToWeek: {
         viewModel.mode.toggle()
       }))
+      .environmentObject(coordinator)
     }
   }
 }

--- a/checky/checky/View/MainView/CalendarView/CalendarView.swift
+++ b/checky/checky/View/MainView/CalendarView/CalendarView.swift
@@ -7,19 +7,22 @@
 
 import SwiftUI
 import Combine
+import EventKit
 
 struct CalendarView: View {
   @EnvironmentObject var coordinator: Coordinator<checkyRouter>
   @StateObject var viewModel: CalendarViewModel = CalendarViewModel()
+  var eventManager: EventManager = EventManager()
+  var reminderManager: ReminderManager = ReminderManager()
   
   var body: some View {
     
     if viewModel.mode {
-      WeeklyStackView(viewModel: WeeklyStackViewModel(dateHolder: DateHolder(), eventManager: EventManager(), reminderManager: ReminderManager(), calendarHelper: WeeklyCalendarHelper(), offsetWidth: UIScreen.main.bounds.width, moveToMonthly: { viewModel.mode.toggle() } ))
+      WeeklyStackView(viewModel: WeeklyStackViewModel(dateHolder: DateHolder(), eventManager: eventManager, reminderManager: reminderManager, calendarHelper: WeeklyCalendarHelper(), offsetWidth: UIScreen.main.bounds.width, moveToMonthly: { viewModel.mode.toggle() } ))
         .environmentObject(coordinator)
 
     } else {
-      MonthlyStackView(viewModel:  MonthlyStackViewModel(dateHolder: DateHolder(), eventManager: EventManager(), reminderManager: ReminderManager(), calendarHelper: MonthyCalendarHelper(), offsetWidth: UIScreen.main.bounds.width, moveToWeek: {
+      MonthlyStackView(viewModel:  MonthlyStackViewModel(dateHolder: DateHolder(), eventManager: eventManager, reminderManager: reminderManager, calendarHelper: MonthyCalendarHelper(), offsetWidth: UIScreen.main.bounds.width, moveToWeek: {
         viewModel.mode.toggle()
       }))
       .environmentObject(coordinator)

--- a/checky/checky/View/MainView/CalendarView/CalendarView.swift
+++ b/checky/checky/View/MainView/CalendarView/CalendarView.swift
@@ -14,9 +14,8 @@ struct CalendarView: View {
   var body: some View {
     
     if viewModel.mode {
-      WeeklyView(viewModel:  WeeklyViewModel(dateHolder: DateHolder(), eventManager: EventManager(), reminderManager: ReminderManager(), calendarHelper: WeeklyCalendarHelper(), moveToMonthly: {
-        viewModel.mode.toggle()
-      }))
+      WeeklyStackView(viewModel: WeeklyStackViewModel(dateHolder: DateHolder(), eventManager: EventManager(), reminderManager: ReminderManager(), calendarHelper: WeeklyCalendarHelper(), offsetWidth: UIScreen.main.bounds.width, moveToMonthly: { viewModel.mode.toggle() } ))
+
     } else {
       MonthlyStackView(viewModel:  MonthlyStackViewModel(dateHolder: DateHolder(), eventManager: EventManager(), reminderManager: ReminderManager(), calendarHelper: MonthyCalendarHelper(), offsetWidth: UIScreen.main.bounds.width, moveToWeek: {
         viewModel.mode.toggle()

--- a/checky/checky/View/MainView/CalendarView/CalendarView.swift
+++ b/checky/checky/View/MainView/CalendarView/CalendarView.swift
@@ -18,7 +18,7 @@ struct CalendarView: View {
         viewModel.mode.toggle()
       }))
     } else {
-      MonthlyView(viewModel:  MonthlyViewModel(dateHolder: DateHolder(), eventManager: EventManager(), reminderManager: ReminderManager(), calendarHelper: MonthyCalendarHelper(), moveToWeek: {
+      MonthlyStackView(viewModel:  MonthlyStackViewModel(dateHolder: DateHolder(), eventManager: EventManager(), reminderManager: ReminderManager(), calendarHelper: MonthyCalendarHelper(), offsetWidth: UIScreen.main.bounds.width, moveToWeek: {
         viewModel.mode.toggle()
       }))
     }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyCellView.swift
@@ -8,16 +8,22 @@
 import SwiftUI
 
 struct DailyCellView: View {
+  @State var event: Event
+  
+  init(event: Event) {
+    self.event = event
+  }
+  
     var body: some View {
       ZStack(alignment: .leading) {
         RoundedRectangle(cornerRadius: 6)
-          .stroke(Color.pointRed)
+          .stroke(Color(event.category.cgColor))
           .background(Color.basicWhite)
           
         HStack {
           ZStack {
             RoundedRectangle(cornerRadius: 4)
-              .fill(Color.pointRed)
+              .fill(Color(event.category.cgColor))
               .frame(width: 40)
             Circle()
               .fill(Color.basicWhite)
@@ -26,21 +32,15 @@ struct DailyCellView: View {
           }
           
           VStack(alignment: .leading) {
-            Text("태엔젤 생일")
+            Text(event.ekevent.title)
               .font(.title3)
               .fontWeight(.semibold)
-            Text("설명충 어쩌구 저쩌구 ")
+            Text(event.ekevent.notes ?? "")
           }
           .padding(.horizontal, 10)
           .padding(.vertical, 6)
         }
       }
       .fixedSize(horizontal: false, vertical: true)
-    }
-}
-
-struct DailyCellView_Previews: PreviewProvider {
-    static var previews: some View {
-        DailyCellView()
     }
 }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyCellView.swift
@@ -15,32 +15,46 @@ struct DailyCellView: View {
   }
   
     var body: some View {
-      ZStack(alignment: .leading) {
-        RoundedRectangle(cornerRadius: 6)
-          .stroke(Color(event.category.cgColor))
-          .background(Color.basicWhite)
-          
-        HStack {
-          ZStack {
-            RoundedRectangle(cornerRadius: 4)
-              .fill(Color(event.category.cgColor))
-              .frame(width: 40)
-            Circle()
-              .fill(Color.basicWhite)
-              .frame(width: 30)
-            Text("😗")
+      HStack(spacing: 4) {
+        if event.ekevent.isAllDay == false {
+          VStack {
+            Text("\(event.ekevent.startDate.time)")
+              .font(.caption2)
+            Rectangle()
+              .frame(width: 1)
+              .frame(maxHeight: .infinity)
+            Text("\(event.ekevent.endDate.time)")
+              .font(.caption2)
           }
-          
-          VStack(alignment: .leading) {
-            Text(event.ekevent.title)
-              .font(.title3)
-              .fontWeight(.semibold)
-            Text(event.ekevent.notes ?? "")
-          }
-          .padding(.horizontal, 10)
-          .padding(.vertical, 6)
         }
+        ZStack(alignment: .leading) {
+          RoundedRectangle(cornerRadius: 6)
+            .stroke(Color(event.category.cgColor))
+            .background(Color.basicWhite)
+            
+          HStack {
+            ZStack {
+              RoundedRectangle(cornerRadius: 4)
+                .fill(Color(event.category.cgColor))
+                .frame(width: 40)
+              Circle()
+                .fill(Color.basicWhite)
+                .frame(width: 30)
+              Text("😗")
+            }
+            
+            VStack(alignment: .leading) {
+              Text(event.ekevent.title)
+                .font(.title3)
+                .fontWeight(.semibold)
+              Text(event.ekevent.notes ?? "")
+                .padding(.leading, 2)
+            }
+            .padding(.horizontal, 4)
+            .padding(.vertical, 6)
+          }
+        }
+        .fixedSize(horizontal: false, vertical: true)
       }
-      .fixedSize(horizontal: false, vertical: true)
     }
 }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyCellView.swift
@@ -48,7 +48,7 @@ struct DailyCellView: View {
                 Text(viewModel.event.ekevent.title)
                   .font(.title3)
                   .fontWeight(.semibold)
-                if viewModel.event.ekevent.notes != "" {
+                if viewModel.event.ekevent.hasNotes {
                   Text(viewModel.event.ekevent.notes ?? "")
                     .padding(.leading, 2)
                 }
@@ -60,7 +60,5 @@ struct DailyCellView: View {
           .fixedSize(horizontal: false, vertical: true)
         }
       }
-
-      
     }
 }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyCellView.swift
@@ -36,7 +36,7 @@ struct DailyCellView: View {
             HStack {
               ZStack {
                 RoundedRectangle(cornerRadius: 4)
-                  .fill(Color(viewModel.event.category.cgColor as! CGColor))
+                  .fill(Color(viewModel.event.category.cgColor))
                   .frame(width: 40)
                 Circle()
                   .fill(Color.basicWhite)

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyCellView.swift
@@ -1,0 +1,46 @@
+//
+//  DailyCellView.swift
+//  checky
+//
+//  Created by RED on 2022/10/29.
+//
+
+import SwiftUI
+
+struct DailyCellView: View {
+    var body: some View {
+      ZStack(alignment: .leading) {
+        RoundedRectangle(cornerRadius: 6)
+          .stroke(Color.pointRed)
+          .background(Color.basicWhite)
+          
+        HStack {
+          ZStack {
+            RoundedRectangle(cornerRadius: 4)
+              .fill(Color.pointRed)
+              .frame(width: 40)
+            Circle()
+              .fill(Color.basicWhite)
+              .frame(width: 30)
+            Text("😗")
+          }
+          
+          VStack(alignment: .leading) {
+            Text("태엔젤 생일")
+              .font(.title3)
+              .fontWeight(.semibold)
+            Text("설명충 어쩌구 저쩌구 ")
+          }
+          .padding(.horizontal, 10)
+          .padding(.vertical, 6)
+        }
+      }
+      .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+struct DailyCellView_Previews: PreviewProvider {
+    static var previews: some View {
+        DailyCellView()
+    }
+}

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyCellView.swift
@@ -46,10 +46,10 @@ struct DailyCellView: View {
               
               VStack(alignment: .leading) {
                 Text(viewModel.event.ekevent.title)
-                  .font(.title3)
-                  .fontWeight(.semibold)
+                  .font(.headline)
                 if viewModel.event.ekevent.hasNotes {
                   Text(viewModel.event.ekevent.notes ?? "")
+                    .font(.footnote)
                     .padding(.leading, 2)
                 }
               }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyCellView.swift
@@ -16,17 +16,17 @@ struct DailyCellView: View {
   
     var body: some View {
       HStack(spacing: 4) {
+        
         if event.ekevent.isAllDay == false {
           VStack {
             Text("\(event.ekevent.startDate.time)")
               .font(.caption2)
-            Rectangle()
-              .frame(width: 1)
-              .frame(maxHeight: .infinity)
+            Spacer()
             Text("\(event.ekevent.endDate.time)")
               .font(.caption2)
           }
         }
+        
         ZStack(alignment: .leading) {
           RoundedRectangle(cornerRadius: 6)
             .stroke(Color(event.category.cgColor))
@@ -47,8 +47,10 @@ struct DailyCellView: View {
               Text(event.ekevent.title)
                 .font(.title3)
                 .fontWeight(.semibold)
-              Text(event.ekevent.notes ?? "")
-                .padding(.leading, 2)
+              if event.ekevent.notes != "" {
+                Text(event.ekevent.notes ?? "")
+                  .padding(.leading, 2)
+              }
             }
             .padding(.horizontal, 4)
             .padding(.vertical, 6)

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyCellView.swift
@@ -8,55 +8,59 @@
 import SwiftUI
 
 struct DailyCellView: View {
-  @State var event: Event
-  
-  init(event: Event) {
-    self.event = event
-  }
+  @EnvironmentObject var coordinator: Coordinator<checkyRouter>
+  @ObservedObject var viewModel: DailyCellViewModel
   
     var body: some View {
-      HStack(spacing: 4) {
-        
-        if event.ekevent.isAllDay == false {
-          VStack {
-            Text("\(event.ekevent.startDate.time)")
-              .font(.caption2)
-            Spacer()
-            Text("\(event.ekevent.endDate.time)")
-              .font(.caption2)
-          }
-        }
-        
-        ZStack(alignment: .leading) {
-          RoundedRectangle(cornerRadius: 6)
-            .stroke(Color(event.category.cgColor))
-            .background(Color.basicWhite)
-            
-          HStack {
-            ZStack {
-              RoundedRectangle(cornerRadius: 4)
-                .fill(Color(event.category.cgColor))
-                .frame(width: 40)
-              Circle()
-                .fill(Color.basicWhite)
-                .frame(width: 30)
-              Text("😗")
+      Button {
+        coordinator.dismiss()
+        coordinator.show(.editEvent(viewModel.event, viewModel.eventManager))
+      } label: {
+        HStack(spacing: 4) {
+          
+          if viewModel.isAllday == false {
+            VStack {
+              Text("\(viewModel.event.ekevent.startDate.time)")
+                .font(.caption2)
+              Spacer()
+              Text("\(viewModel.event.ekevent.endDate.time)")
+                .font(.caption2)
             }
-            
-            VStack(alignment: .leading) {
-              Text(event.ekevent.title)
-                .font(.title3)
-                .fontWeight(.semibold)
-              if event.ekevent.notes != "" {
-                Text(event.ekevent.notes ?? "")
-                  .padding(.leading, 2)
+          }
+          
+          ZStack(alignment: .leading) {
+            RoundedRectangle(cornerRadius: 6)
+              .stroke(Color(viewModel.event.category.cgColor))
+              .background(Color.basicWhite)
+              
+            HStack {
+              ZStack {
+                RoundedRectangle(cornerRadius: 4)
+                  .fill(Color(viewModel.event.category.cgColor as! CGColor))
+                  .frame(width: 40)
+                Circle()
+                  .fill(Color.basicWhite)
+                  .frame(width: 30)
+                Text("😗")
               }
+              
+              VStack(alignment: .leading) {
+                Text(viewModel.event.ekevent.title)
+                  .font(.title3)
+                  .fontWeight(.semibold)
+                if viewModel.event.ekevent.notes != "" {
+                  Text(viewModel.event.ekevent.notes ?? "")
+                    .padding(.leading, 2)
+                }
+              }
+              .padding(.horizontal, 4)
+              .padding(.vertical, 6)
             }
-            .padding(.horizontal, 4)
-            .padding(.vertical, 6)
           }
+          .fixedSize(horizontal: false, vertical: true)
         }
-        .fixedSize(horizontal: false, vertical: true)
       }
+
+      
     }
 }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyCellViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyCellViewModel.swift
@@ -1,13 +1,13 @@
 //
-//  DailyViewModel.swift
+//  DailyCellViewModel.swift
 //  checky
 //
-//  Created by RED on 2022/10/29.
+//  Created by RED on 2022/10/31.
 //
 
 import Foundation
 
-class DailyViewModel: ViewModelable {
+class DailyCellViewModel: ViewModelable {
   @Published var events: [Event]
   @Published var allDayEvents: [Event]
   @Published var timeEvents: [Event]

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyCellViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyCellViewModel.swift
@@ -8,26 +8,17 @@
 import Foundation
 
 class DailyCellViewModel: ViewModelable {
-  @Published var events: [Event]
-  @Published var allDayEvents: [Event]
-  @Published var timeEvents: [Event]
-  
-  @Published var reminders: [Reminder]
-//  @State var dayReminders: [Event]
-//  @State var timeReminders: [Event]
+  @Published var event: Event
   var eventManager: EventManager
-  var reminderManager: ReminderManager
   
-  init(events: [Event],
-       reminders: [Reminder],
-       eventManager: EventManager,
-       reminderManager: ReminderManager) {
-    self.events = events
-    self.allDayEvents = events.filter { $0.ekevent.isAllDay == true }
-    self.timeEvents = events.filter { $0.ekevent.isAllDay == false }
-    self.reminders = reminders
+  init(event: Event,
+       eventManager: EventManager) {
+    self.event = event
     self.eventManager = eventManager
-    self.reminderManager = reminderManager
+  }
+  
+  var isAllday: Bool {
+    return event.ekevent.isAllDay
   }
   
   enum Action {
@@ -37,4 +28,5 @@ class DailyCellViewModel: ViewModelable {
   func action(_ action: Action) {
     
   }
+  
 }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyHeaderView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyHeaderView.swift
@@ -1,0 +1,28 @@
+//
+//  DailyHeaderView.swift
+//  checky
+//
+//  Created by RED on 2022/11/02.
+//
+
+import SwiftUI
+
+struct DailyHeaderView: View {
+  @State var date: Date
+  let calendarHelper = WeeklyCalendarHelper()
+    
+    var body: some View {
+        Text(displayMonth)
+            .font(.title)
+            .bold()
+            .foregroundColor(Color.fontBlack)
+            .animation(.none)
+            .frame(maxWidth: .infinity)
+            .background(Color.basicWhite)
+            .padding(.top)
+    }
+  
+  var displayMonth: String {
+    return calendarHelper.monthYearDayString(date)
+  }
+}

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCell.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCell.swift
@@ -1,0 +1,69 @@
+//
+//  DailyReminderCell.swift
+//  checky
+//
+//  Created by RED on 2022/10/31.
+//
+
+import SwiftUI
+import EventKit
+
+struct DailyReminderCell: View {
+  @ObservedObject var viewModel: DailyReminderCellViewModel
+  
+    var body: some View {
+      HStack(spacing: 4) {
+        
+        if viewModel.reminder.ekreminder.startDateComponents?.minute != nil {
+          VStack {
+            Text("\(Calendar(identifier: .gregorian).date(from: viewModel.reminder.ekreminder.startDateComponents!)?.time ?? Date().time)")
+              .font(.caption2)
+          }
+        }
+        
+        ZStack(alignment: .leading) {
+          RoundedRectangle(cornerRadius: 6)
+            .stroke(Color(viewModel.reminder.category.cgColor))
+            .background(Color.basicWhite)
+            
+          HStack {
+            ZStack {
+              RoundedRectangle(cornerRadius: 4)
+                .fill(Color(viewModel.reminder.category.cgColor))
+                .frame(width: 40)
+              
+              Button {
+                //
+                viewModel.action(.tappedCompletion)
+              } label: {
+                ZStack {
+                  Circle()
+                    .fill(Color.basicWhite)
+                    .frame(width: 30)
+                  
+                  if viewModel.isCompletion {
+                    Circle()
+                      .fill(Color(viewModel.reminder.category.cgColor))
+                      .frame(width: 20)
+                  }
+                }
+              }
+            }
+            
+            VStack(alignment: .leading) {
+              Text(viewModel.reminder.ekreminder.title)
+                .font(.title3)
+                .fontWeight(.semibold)
+              if viewModel.reminder.ekreminder.notes != "" {
+                Text(viewModel.reminder.ekreminder.notes ?? "")
+                  .padding(.leading, 2)
+              }
+            }
+            .padding(.horizontal, 4)
+            .padding(.vertical, 6)
+          }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+}

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCell.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCell.swift
@@ -44,7 +44,7 @@ struct DailyReminderCell: View {
             Text(viewModel.reminder.ekreminder.title)
               .font(.title3)
               .fontWeight(.semibold)
-            if viewModel.reminder.ekreminder.notes != "" {
+            if viewModel.reminder.ekreminder.hasNotes {
               Text(viewModel.reminder.ekreminder.notes ?? "")
                 .padding(.leading, 2)
             }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCell.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCell.swift
@@ -14,13 +14,6 @@ struct DailyReminderCell: View {
   var body: some View {
     HStack(spacing: 4) {
       
-      if viewModel.reminder.ekreminder.dueDateComponents?.minute != nil {
-        VStack {
-          Text("\(Calendar(identifier: .gregorian).date(from: viewModel.reminder.ekreminder.dueDateComponents!)?.time ?? Date().time)")
-            .font(.caption2)
-        }
-      }
-      
       ZStack(alignment: .leading) {
         RoundedRectangle(cornerRadius: 6)
           .stroke(Color(viewModel.reminder.category.cgColor))

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCell.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCell.swift
@@ -11,59 +11,56 @@ import EventKit
 struct DailyReminderCell: View {
   @ObservedObject var viewModel: DailyReminderCellViewModel
   
-    var body: some View {
-      HStack(spacing: 4) {
-        
-        if viewModel.reminder.ekreminder.startDateComponents?.minute != nil {
-          VStack {
-            Text("\(Calendar(identifier: .gregorian).date(from: viewModel.reminder.ekreminder.startDateComponents!)?.time ?? Date().time)")
-              .font(.caption2)
-          }
+  var body: some View {
+    HStack(spacing: 4) {
+      
+      if viewModel.reminder.ekreminder.dueDateComponents?.minute != nil {
+        VStack {
+          Text("\(Calendar(identifier: .gregorian).date(from: viewModel.reminder.ekreminder.dueDateComponents!)?.time ?? Date().time)")
+            .font(.caption2)
         }
-        
-        ZStack(alignment: .leading) {
-          RoundedRectangle(cornerRadius: 6)
-            .stroke(Color(viewModel.reminder.category.cgColor))
-            .background(Color.basicWhite)
-            
-          HStack {
-            ZStack {
-              RoundedRectangle(cornerRadius: 4)
-                .fill(Color(viewModel.reminder.category.cgColor))
-                .frame(width: 40)
-              
-              Button {
-                //
-                viewModel.action(.tappedCompletion)
-              } label: {
-                ZStack {
-                  Circle()
-                    .fill(Color.basicWhite)
-                    .frame(width: 30)
-                  
-                  if viewModel.isCompletion {
-                    Circle()
-                      .fill(Color(viewModel.reminder.category.cgColor))
-                      .frame(width: 20)
-                  }
-                }
-              }
-            }
-            
-            VStack(alignment: .leading) {
-              Text(viewModel.reminder.ekreminder.title)
-                .font(.title3)
-                .fontWeight(.semibold)
-              if viewModel.reminder.ekreminder.notes != "" {
-                Text(viewModel.reminder.ekreminder.notes ?? "")
-                  .padding(.leading, 2)
-              }
-            }
-            .padding(.horizontal, 4)
-            .padding(.vertical, 6)
-          }
-        }
-        .fixedSize(horizontal: false, vertical: true)
       }
+      
+      ZStack(alignment: .leading) {
+        RoundedRectangle(cornerRadius: 6)
+          .stroke(Color(viewModel.reminder.category.cgColor))
+          .background(Color.basicWhite)
+        
+        HStack {
+          
+          Button {
+            //
+            viewModel.action(.tappedCompletion)
+          } label: {
+            ZStack {
+              Circle()
+                .stroke(Color(viewModel.reminder.category.cgColor))
+                .background(Color.basicWhite)
+                .frame(width: 30)
+              
+              if viewModel.isCompletion {
+                Circle()
+                  .fill(Color(viewModel.reminder.category.cgColor))
+                  .frame(width: 20)
+              }
+            }
+          }
+          .padding(.leading, 4)
+          
+          VStack(alignment: .leading) {
+            Text(viewModel.reminder.ekreminder.title)
+              .font(.title3)
+              .fontWeight(.semibold)
+            if viewModel.reminder.ekreminder.notes != "" {
+              Text(viewModel.reminder.ekreminder.notes ?? "")
+                .padding(.leading, 2)
+            }
+          }
+          .padding(.horizontal, 4)
+          .padding(.vertical, 6)
+        }
+      }
+      .fixedSize(horizontal: false, vertical: true)
     }
+  }
 }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCellVeiwModel.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCellVeiwModel.swift
@@ -6,13 +6,11 @@
 //
 
 import Foundation
-import Combine
 
 class DailyReminderCellViewModel: ViewModelable {
   @Published var reminder: Reminder
   @Published var isCompletion: Bool
   var reminderManager: ReminderManager
-  var store =  Set<AnyCancellable>()
   
   init(reminder: Reminder,
        reminderManager: ReminderManager) {

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCellVeiwModel.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCellVeiwModel.swift
@@ -1,0 +1,41 @@
+//
+//  DailyReminderCellVeiwModel.swift
+//  checky
+//
+//  Created by RED on 2022/10/31.
+//
+
+import Foundation
+import Combine
+
+class DailyReminderCellViewModel: ViewModelable {
+  @Published var reminder: Reminder
+  @Published var isCompletion: Bool
+  var reminderManager: ReminderManager
+  var store =  Set<AnyCancellable>()
+  
+  init(reminder: Reminder,
+       reminderManager: ReminderManager) {
+    self.reminder = reminder
+    self.isCompletion = reminder.ekreminder.isCompleted
+    self.reminderManager = reminderManager
+  }
+  
+  enum Action {
+    case tappedCompletion
+  }
+  
+  func action(_ action: Action) {
+    switch action {
+      case .tappedCompletion:
+        reminder.ekreminder.isCompleted.toggle()
+        let result = reminderManager.editReminder(reminder.ekreminder)
+        switch result {
+          case .success(let success):
+            isCompletion = success
+          case .failure(let failure):
+            print(failure.localizedDescription)
+        }
+    }
+  }
+}

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCellVeiwModel.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCellVeiwModel.swift
@@ -10,6 +10,7 @@ import Foundation
 class DailyReminderCellViewModel: ViewModelable {
   @Published var reminder: Reminder
   @Published var isCompletion: Bool
+  
   var reminderManager: ReminderManager
   
   init(reminder: Reminder,

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCellView.swift
@@ -50,10 +50,10 @@ struct DailyReminderCellView: View {
             HStack {
               VStack(alignment: .leading) {
                 Text(viewModel.reminder.ekreminder.title)
-                  .font(.title3)
-                  .fontWeight(.semibold)
+                  .font(.headline)
                 if viewModel.reminder.ekreminder.hasNotes {
                   Text(viewModel.reminder.ekreminder.notes ?? "")
+                    .font(.footnote)
                     .padding(.leading, 2)
                     .multilineTextAlignment(.leading)
                 }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCellView.swift
@@ -24,7 +24,6 @@ struct DailyReminderCellView: View {
         HStack {
           
           Button {
-            //
             viewModel.action(.tappedCompletion)
           } label: {
             ZStack {
@@ -43,7 +42,6 @@ struct DailyReminderCellView: View {
           .padding(.leading, 4)
           
           Button {
-            //
             coordinator.dismiss()
             coordinator.show(.editReminder(viewModel.reminder, viewModel.reminderManager))
           } label: {

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyReminderCellView.swift
@@ -8,10 +8,12 @@
 import SwiftUI
 import EventKit
 
-struct DailyReminderCell: View {
+struct DailyReminderCellView: View {
+  @EnvironmentObject var coordinator: Coordinator<checkyRouter>
   @ObservedObject var viewModel: DailyReminderCellViewModel
   
   var body: some View {
+
     HStack(spacing: 4) {
       
       ZStack(alignment: .leading) {
@@ -40,17 +42,27 @@ struct DailyReminderCell: View {
           }
           .padding(.leading, 4)
           
-          VStack(alignment: .leading) {
-            Text(viewModel.reminder.ekreminder.title)
-              .font(.title3)
-              .fontWeight(.semibold)
-            if viewModel.reminder.ekreminder.hasNotes {
-              Text(viewModel.reminder.ekreminder.notes ?? "")
-                .padding(.leading, 2)
+          Button {
+            //
+            coordinator.dismiss()
+            coordinator.show(.editReminder(viewModel.reminder, viewModel.reminderManager))
+          } label: {
+            HStack {
+              VStack(alignment: .leading) {
+                Text(viewModel.reminder.ekreminder.title)
+                  .font(.title3)
+                  .fontWeight(.semibold)
+                if viewModel.reminder.ekreminder.hasNotes {
+                  Text(viewModel.reminder.ekreminder.notes ?? "")
+                    .padding(.leading, 2)
+                    .multilineTextAlignment(.leading)
+                }
+              }
+              .padding(.horizontal, 4)
+              .padding(.vertical, 6)
+              Spacer()
             }
           }
-          .padding(.horizontal, 4)
-          .padding(.vertical, 6)
         }
       }
       .fixedSize(horizontal: false, vertical: true)

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
@@ -20,29 +20,79 @@ struct DailyView: View {
     VStack {
       HeaderView(viewModel: HeaderViewModel(dateHolder: DateHolder(), calendarHelper: WeeklyCalendarHelper()))
       ScrollView(.vertical) {
-        ZStack {
-          RoundedRectangle(cornerRadius: 4)
-            .fill(Color.basicWhite)
-          VStack(spacing: 10) {
-            ForEach(viewModel.allDayEvents, id: \.self) { event in
-              DailyCellView(event: event)
-            }
-            
-            ForEach(viewModel.reminders, id: \.self) { reminder in
-              DailyReminderCell(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
-            }
-            
-            ForEach(0..<viewModel.timeEvents.count, id: \.self) { index in
-              VStack(alignment: .leading) {
-                DailyCellView(event: viewModel.timeEvents[index])
-              }
-            }
-          }
-          .padding()
+        VStack {
+          eventView
+            .padding()
+          Text("마감 임박 일정")
+          reminderView
+            .padding()
+          Text("오늘 완료한 일정")
+          clearReminderView
+            .padding()
         }
-        .padding()
       }
       .background(Color.backgroundGray)
+    }
+  }
+  
+  var eventView: some View {
+    ZStack {
+      RoundedRectangle(cornerRadius: 4)
+        .fill(Color.basicWhite)
+      VStack(spacing: 10) {
+        // 하루종일 일정
+        ForEach(viewModel.allDayEvents, id: \.self) { event in
+          DailyCellView(event: event)
+        }
+        
+        // 시간이 정해져 있는 이벤트
+        ForEach(0..<viewModel.timeEvents.count, id: \.self) { index in
+          VStack(alignment: .leading) {
+            DailyCellView(event: viewModel.timeEvents[index])
+          }
+        }
+      }
+      .padding()
+    }
+  }
+  
+  var reminderView: some View {
+    ZStack {
+      RoundedRectangle(cornerRadius: 4)
+        .fill(Color.basicWhite)
+      VStack(spacing: 10) {
+        
+        // 하루종일 reminder
+        ForEach(viewModel.dayReminders, id: \.self) { reminder in
+          DailyReminderCell(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
+        }
+        
+        // 시간이 정해져 있는 리마인더
+        ForEach(viewModel.timeReminders, id: \.self) { reminder in
+          DailyReminderCell(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
+        }
+      }
+      .padding()
+    }
+  }
+  
+  var clearReminderView: some View {
+    ZStack {
+      RoundedRectangle(cornerRadius: 4)
+        .fill(Color.basicWhite)
+      VStack(spacing: 10) {
+        
+        // 하루종일 reminder
+        ForEach(viewModel.dayReminders, id: \.self) { reminder in
+          DailyReminderCell(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
+        }
+        
+        // 시간이 정해져 있는 리마인더
+        ForEach(viewModel.timeReminders, id: \.self) { reminder in
+          DailyReminderCell(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
+        }
+      }
+      .padding()
     }
   }
 }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
@@ -6,14 +6,22 @@
 //
 
 import SwiftUI
+import EventKit
 
 struct DailyView: View {
   @EnvironmentObject var coordinator: Coordinator<checkyRouter>
   
   @State var events: [Event]
+  @State var allDayEvents: [Event]
+  @State var timeEvents: [Event]
   
   init(events: [Event]) {
     self.events = events
+    self.allDayEvents = events.filter { $0.ekevent.isAllDay == true }
+    self.timeEvents = events.filter { $0.ekevent.isAllDay == false }
+      .sorted { first, second in
+        return first.ekevent.startDate < second.ekevent.startDate
+      }
   }
   
   var body: some View {
@@ -24,16 +32,40 @@ struct DailyView: View {
           RoundedRectangle(cornerRadius: 4)
             .fill(Color.basicWhite)
           VStack(spacing: 10) {
-          ForEach(events, id: \.self) { event in
-            let _ = print(event)
+            ForEach(allDayEvents, id: \.self) { event in
               DailyCellView(event: event)
+            }
+            ForEach(0..<timeEvents.count, id: \.self) { index in
+              VStack(alignment: .leading) {
+                Button {
+                  //
+                } label: {
+                  if index == 0 {
+                    EmptyView()
+                  } else if timeEvents[index-1].ekevent.overlapTime(timeEvents[index].ekevent) {
+                    Image(systemName: "infinity")
+                      .padding(.leading, 20)
+                  } else {
+                    Image(systemName: "plus.circle")
+                      .padding(.leading, 20)
+                  }
+                }
+
+                DailyCellView(event: timeEvents[index])
+              }
             }
           }
           .padding()
         }
-        .padding(.horizontal)
+        .padding()
       }
+      .background(Color.backgroundGray)
     }
-    .background(Color.backgroundGray)
+  }
+}
+
+extension EKEvent {
+  func overlapTime(_ event: EKEvent) -> Bool {
+    return self.endDate > event.startDate
   }
 }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
@@ -74,6 +74,7 @@ struct DailyView: View {
         ForEach(viewModel.allDayEvents, id: \.self) { event in
           DailyCellView(viewModel: DailyCellViewModel(event: event, eventManager: viewModel.eventManager))
             .environmentObject(coordinator)
+            .foregroundColor(Color.fontBlack)
         }
         
         // 시간이 정해져 있는 이벤트
@@ -81,6 +82,7 @@ struct DailyView: View {
           VStack(alignment: .leading) {
             DailyCellView(viewModel: DailyCellViewModel(event: viewModel.timeEvents[index], eventManager: viewModel.eventManager))
               .environmentObject(coordinator)
+              .foregroundColor(Color.fontBlack)
           }
         }
       }
@@ -98,12 +100,14 @@ struct DailyView: View {
         ForEach(viewModel.dayReminders, id: \.self) { reminder in
           DailyReminderCellView(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
             .environmentObject(coordinator)
+            .foregroundColor(Color.fontBlack)
         }
         
         // 시간이 정해져 있는 리마인더
         ForEach(viewModel.timeReminders, id: \.self) { reminder in
           DailyReminderCellView(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
             .environmentObject(coordinator)
+            .foregroundColor(Color.fontBlack)
         }
       }
       .padding()
@@ -119,6 +123,7 @@ struct DailyView: View {
         // 하루종일 reminder
         ForEach(viewModel.clearedReminders, id: \.self) { reminder in
           DailyReminderCellView(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
+            .foregroundColor(Color.fontBlack)
         }
       }
       .padding()

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
@@ -20,15 +20,45 @@ struct DailyView: View {
     VStack {
       HeaderView(viewModel: HeaderViewModel(dateHolder: DateHolder(), calendarHelper: WeeklyCalendarHelper()))
       ScrollView(.vertical) {
-        VStack {
-          eventView
+        VStack(alignment: .leading) {
+          if viewModel.events.count == 0 {
+            VStack(alignment: .center) {
+              Text("오늘은 일정이 없어요!")
+                .padding(.top)
+                .frame(maxWidth: .infinity)
+            }
+          } else {
+            VStack(alignment: .leading, spacing: 4) {
+              Text("오늘 일정")
+                .padding(.leading, 4)
+              eventView
+            }
             .padding()
-          Text("마감 임박 일정")
-          reminderView
+          }
+          
+          if viewModel.dayReminders.count == 0 && viewModel.timeReminders.count == 0 {
+  
+          } else {
+            VStack(alignment: .leading, spacing: 4) {
+              Text("오늘이 마감인 미리알림")
+                .padding(.leading, 4)
+              reminderView
+            }
             .padding()
-          Text("오늘 완료한 일정")
-          clearReminderView
+          }
+          
+          if viewModel.clearedReminders.count == 0 {
+  
+          } else {
+            VStack(alignment: .leading, spacing: 4) {
+              Text("오늘 완료한 미리알림")
+                .padding(.leading, 4)
+              clearReminderView
+            }
             .padding()
+          }
+          
+          
         }
       }
       .background(Color.backgroundGray)
@@ -83,12 +113,7 @@ struct DailyView: View {
       VStack(spacing: 10) {
         
         // 하루종일 reminder
-        ForEach(viewModel.dayReminders, id: \.self) { reminder in
-          DailyReminderCell(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
-        }
-        
-        // 시간이 정해져 있는 리마인더
-        ForEach(viewModel.timeReminders, id: \.self) { reminder in
+        ForEach(viewModel.clearedReminders, id: \.self) { reminder in
           DailyReminderCell(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
         }
       }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
@@ -1,0 +1,54 @@
+//
+//  DailyView.swift
+//  checky
+//
+//  Created by RED on 2022/10/29.
+//
+
+import SwiftUI
+
+struct DailyView: View {
+  var body: some View {
+    VStack {
+      HeaderView(viewModel: HeaderViewModel(dateHolder: DateHolder(), calendarHelper: WeeklyCalendarHelper()))
+      VStack {
+        
+        ZStack(alignment: .leading) {
+          RoundedRectangle(cornerRadius: 6)
+            .stroke(Color.pointRed)
+            .background(Color.basicWhite)
+            
+          HStack {
+            ZStack {
+              RoundedRectangle(cornerRadius: 4)
+                .fill(Color.pointRed)
+                .frame(width: 40)
+              Circle()
+                .fill(Color.basicWhite)
+                .frame(width: 30)
+              Text("😗")
+            }
+            
+            VStack(alignment: .leading) {
+              Text("태엔젤 생일")
+                .font(.title3)
+                .fontWeight(.semibold)
+              Text("설명충 어쩌구 저쩌구 ")
+            }
+            .padding()
+          }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .padding()
+        
+      }
+    }
+    .background(Color.backgroundGray)
+  }
+}
+
+struct DailyView_Previews: PreviewProvider {
+  static var previews: some View {
+    DailyView()
+  }
+}

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
@@ -96,13 +96,13 @@ struct DailyView: View {
         
         // 하루종일 reminder
         ForEach(viewModel.dayReminders, id: \.self) { reminder in
-          DailyReminderCell(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
+          DailyReminderCellView(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
             .environmentObject(coordinator)
         }
         
         // 시간이 정해져 있는 리마인더
         ForEach(viewModel.timeReminders, id: \.self) { reminder in
-          DailyReminderCell(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
+          DailyReminderCellView(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
             .environmentObject(coordinator)
         }
       }
@@ -118,7 +118,7 @@ struct DailyView: View {
         
         // 하루종일 reminder
         ForEach(viewModel.clearedReminders, id: \.self) { reminder in
-          DailyReminderCell(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
+          DailyReminderCellView(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
         }
       }
       .padding()

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
@@ -8,6 +8,14 @@
 import SwiftUI
 
 struct DailyView: View {
+  @EnvironmentObject var coordinator: Coordinator<checkyRouter>
+  
+  @State var events: [Event]
+  
+  init(events: [Event]) {
+    self.events = events
+  }
+  
   var body: some View {
     VStack {
       HeaderView(viewModel: HeaderViewModel(dateHolder: DateHolder(), calendarHelper: WeeklyCalendarHelper()))
@@ -16,8 +24,10 @@ struct DailyView: View {
           RoundedRectangle(cornerRadius: 4)
             .fill(Color.basicWhite)
           VStack(spacing: 10) {
-            DailyCellView()
-            DailyCellView()
+          ForEach(events, id: \.self) { event in
+            let _ = print(event)
+              DailyCellView(event: event)
+            }
           }
           .padding()
         }
@@ -25,11 +35,5 @@ struct DailyView: View {
       }
     }
     .background(Color.backgroundGray)
-  }
-}
-
-struct DailyView_Previews: PreviewProvider {
-  static var previews: some View {
-    DailyView()
   }
 }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
@@ -36,9 +36,7 @@ struct DailyView: View {
             .padding()
           }
           
-          if viewModel.dayReminders.count == 0 && viewModel.timeReminders.count == 0 {
-            
-          } else {
+          if viewModel.dayReminders.count != 0 || viewModel.timeReminders.count != 0 {
             VStack(alignment: .leading, spacing: 4) {
               Text("오늘이 마감인 미리알림")
                 .padding(.leading, 4)

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
@@ -70,14 +70,13 @@ struct DailyView: View {
       RoundedRectangle(cornerRadius: 4)
         .fill(Color.basicWhite)
       VStack(spacing: 10) {
-        // 하루종일 일정
+  
         ForEach(viewModel.allDayEvents, id: \.self) { event in
           DailyCellView(viewModel: DailyCellViewModel(event: event, eventManager: viewModel.eventManager))
             .environmentObject(coordinator)
             .foregroundColor(Color.fontBlack)
         }
         
-        // 시간이 정해져 있는 이벤트
         ForEach(0..<viewModel.timeEvents.count, id: \.self) { index in
           VStack(alignment: .leading) {
             DailyCellView(viewModel: DailyCellViewModel(event: viewModel.timeEvents[index], eventManager: viewModel.eventManager))
@@ -96,14 +95,12 @@ struct DailyView: View {
         .fill(Color.basicWhite)
       VStack(spacing: 10) {
         
-        // 하루종일 reminder
         ForEach(viewModel.dayReminders, id: \.self) { reminder in
           DailyReminderCellView(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
             .environmentObject(coordinator)
             .foregroundColor(Color.fontBlack)
         }
         
-        // 시간이 정해져 있는 리마인더
         ForEach(viewModel.timeReminders, id: \.self) { reminder in
           DailyReminderCellView(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
             .environmentObject(coordinator)
@@ -120,7 +117,6 @@ struct DailyView: View {
         .fill(Color.basicWhite)
       VStack(spacing: 10) {
         
-        // 하루종일 reminder
         ForEach(viewModel.clearedReminders, id: \.self) { reminder in
           DailyReminderCellView(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
             .foregroundColor(Color.fontBlack)
@@ -128,11 +124,5 @@ struct DailyView: View {
       }
       .padding()
     }
-  }
-}
-
-extension EKEvent {
-  func overlapTime(_ event: EKEvent) -> Bool {
-    return self.endDate > event.startDate
   }
 }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
@@ -72,13 +72,15 @@ struct DailyView: View {
       VStack(spacing: 10) {
         // 하루종일 일정
         ForEach(viewModel.allDayEvents, id: \.self) { event in
-          DailyCellView(event: event)
+          DailyCellView(viewModel: DailyCellViewModel(event: event, eventManager: viewModel.eventManager))
+            .environmentObject(coordinator)
         }
         
         // 시간이 정해져 있는 이벤트
         ForEach(0..<viewModel.timeEvents.count, id: \.self) { index in
           VStack(alignment: .leading) {
-            DailyCellView(event: viewModel.timeEvents[index])
+            DailyCellView(viewModel: DailyCellViewModel(event: viewModel.timeEvents[index], eventManager: viewModel.eventManager))
+              .environmentObject(coordinator)
           }
         }
       }
@@ -95,11 +97,13 @@ struct DailyView: View {
         // 하루종일 reminder
         ForEach(viewModel.dayReminders, id: \.self) { reminder in
           DailyReminderCell(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
+            .environmentObject(coordinator)
         }
         
         // 시간이 정해져 있는 리마인더
         ForEach(viewModel.timeReminders, id: \.self) { reminder in
           DailyReminderCell(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
+            .environmentObject(coordinator)
         }
       }
       .padding()

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
@@ -11,36 +11,17 @@ struct DailyView: View {
   var body: some View {
     VStack {
       HeaderView(viewModel: HeaderViewModel(dateHolder: DateHolder(), calendarHelper: WeeklyCalendarHelper()))
-      VStack {
-        
-        ZStack(alignment: .leading) {
-          RoundedRectangle(cornerRadius: 6)
-            .stroke(Color.pointRed)
-            .background(Color.basicWhite)
-            
-          HStack {
-            ZStack {
-              RoundedRectangle(cornerRadius: 4)
-                .fill(Color.pointRed)
-                .frame(width: 40)
-              Circle()
-                .fill(Color.basicWhite)
-                .frame(width: 30)
-              Text("😗")
-            }
-            
-            VStack(alignment: .leading) {
-              Text("태엔젤 생일")
-                .font(.title3)
-                .fontWeight(.semibold)
-              Text("설명충 어쩌구 저쩌구 ")
-            }
-            .padding()
+      ScrollView(.vertical) {
+        ZStack {
+          RoundedRectangle(cornerRadius: 4)
+            .fill(Color.basicWhite)
+          VStack(spacing: 10) {
+            DailyCellView()
+            DailyCellView()
           }
+          .padding()
         }
-        .fixedSize(horizontal: false, vertical: true)
-        .padding()
-        
+        .padding(.horizontal)
       }
     }
     .background(Color.backgroundGray)

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
@@ -10,18 +10,10 @@ import EventKit
 
 struct DailyView: View {
   @EnvironmentObject var coordinator: Coordinator<checkyRouter>
+  @ObservedObject var viewModel: DailyViewModel
   
-  @State var events: [Event]
-  @State var allDayEvents: [Event]
-  @State var timeEvents: [Event]
-  
-  init(events: [Event]) {
-    self.events = events
-    self.allDayEvents = events.filter { $0.ekevent.isAllDay == true }
-    self.timeEvents = events.filter { $0.ekevent.isAllDay == false }
-      .sorted { first, second in
-        return first.ekevent.startDate < second.ekevent.startDate
-      }
+  init(viewModel: DailyViewModel) {
+    self.viewModel = viewModel
   }
   
   var body: some View {
@@ -32,26 +24,17 @@ struct DailyView: View {
           RoundedRectangle(cornerRadius: 4)
             .fill(Color.basicWhite)
           VStack(spacing: 10) {
-            ForEach(allDayEvents, id: \.self) { event in
+            ForEach(viewModel.allDayEvents, id: \.self) { event in
               DailyCellView(event: event)
             }
-            ForEach(0..<timeEvents.count, id: \.self) { index in
+            
+            ForEach(viewModel.reminders, id: \.self) { reminder in
+              DailyReminderCell(viewModel: DailyReminderCellViewModel(reminder: reminder, reminderManager: viewModel.reminderManager))
+            }
+            
+            ForEach(0..<viewModel.timeEvents.count, id: \.self) { index in
               VStack(alignment: .leading) {
-                Button {
-                  //
-                } label: {
-                  if index == 0 {
-                    EmptyView()
-                  } else if timeEvents[index-1].ekevent.overlapTime(timeEvents[index].ekevent) {
-                    Image(systemName: "infinity")
-                      .padding(.leading, 20)
-                  } else {
-                    Image(systemName: "plus.circle")
-                      .padding(.leading, 20)
-                  }
-                }
-
-                DailyCellView(event: timeEvents[index])
+                DailyCellView(event: viewModel.timeEvents[index])
               }
             }
           }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
@@ -37,7 +37,7 @@ struct DailyView: View {
           }
           
           if viewModel.dayReminders.count == 0 && viewModel.timeReminders.count == 0 {
-  
+            
           } else {
             VStack(alignment: .leading, spacing: 4) {
               Text("오늘이 마감인 미리알림")
@@ -48,7 +48,7 @@ struct DailyView: View {
           }
           
           if viewModel.clearedReminders.count == 0 {
-  
+            
           } else {
             VStack(alignment: .leading, spacing: 4) {
               Text("오늘 완료한 미리알림")
@@ -57,8 +57,6 @@ struct DailyView: View {
             }
             .padding()
           }
-          
-          
         }
       }
       .background(Color.backgroundGray)
@@ -70,7 +68,7 @@ struct DailyView: View {
       RoundedRectangle(cornerRadius: 4)
         .fill(Color.basicWhite)
       VStack(spacing: 10) {
-  
+        
         ForEach(viewModel.allDayEvents, id: \.self) { event in
           DailyCellView(viewModel: DailyCellViewModel(event: event, eventManager: viewModel.eventManager))
             .environmentObject(coordinator)

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyView.swift
@@ -18,7 +18,7 @@ struct DailyView: View {
   
   var body: some View {
     VStack {
-      HeaderView(viewModel: HeaderViewModel(dateHolder: DateHolder(), calendarHelper: WeeklyCalendarHelper()))
+      DailyHeaderView(date: viewModel.date)
       ScrollView(.vertical) {
         VStack(alignment: .leading) {
           if viewModel.events.count == 0 {

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 class DailyViewModel: ViewModelable {
+  @Published var date: Date
   @Published var events: [Event]
   @Published var allDayEvents: [Event]
   @Published var timeEvents: [Event]
@@ -21,11 +22,13 @@ class DailyViewModel: ViewModelable {
   var eventManager: EventManager
   var reminderManager: ReminderManager
   
-  init(events: [Event],
+  init(date: Date,
+       events: [Event],
        reminders: [Reminder],
        clearedReminders: [Reminder],
        eventManager: EventManager,
        reminderManager: ReminderManager) {
+    self.date = date
     self.events = events
     self.allDayEvents = events.filter { $0.ekevent.isAllDay == true }
     

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyViewModel.swift
@@ -9,15 +9,12 @@ import Foundation
 
 class DailyViewModel: ViewModelable {
   @Published var date: Date
-  
   @Published var events: [Event]
   @Published var allDayEvents: [Event]
   @Published var timeEvents: [Event]
-  
   @Published var reminders: [Reminder]
   @Published var dayReminders: [Reminder]
   @Published var timeReminders: [Reminder]
-  
   @Published var clearedReminders: [Reminder]
   
   var eventManager: EventManager

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyViewModel.swift
@@ -16,13 +16,14 @@ class DailyViewModel: ViewModelable {
   @Published var dayReminders: [Reminder]
   @Published var timeReminders: [Reminder]
   
-//  @Published var compeletedReminders: [Reminder]
+  @Published var clearedReminders: [Reminder]
   
   var eventManager: EventManager
   var reminderManager: ReminderManager
   
   init(events: [Event],
        reminders: [Reminder],
+       clearedReminders: [Reminder],
        eventManager: EventManager,
        reminderManager: ReminderManager) {
     self.events = events
@@ -32,7 +33,7 @@ class DailyViewModel: ViewModelable {
     self.dayReminders = reminders.filter { $0.ekreminder.dueDateComponents?.day != nil && $0.ekreminder.dueDateComponents?.hour == nil }
     self.timeEvents = events.filter { $0.ekevent.isAllDay == false }
     self.timeReminders = reminders.filter { $0.ekreminder.dueDateComponents?.hour != nil }
-    
+    self.clearedReminders = clearedReminders
     self.eventManager = eventManager
     self.reminderManager = reminderManager
   }

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyViewModel.swift
@@ -9,6 +9,7 @@ import Foundation
 
 class DailyViewModel: ViewModelable {
   @Published var date: Date
+  
   @Published var events: [Event]
   @Published var allDayEvents: [Event]
   @Published var timeEvents: [Event]

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyViewModel.swift
@@ -1,0 +1,19 @@
+//
+//  DailyViewModel.swift
+//  checky
+//
+//  Created by RED on 2022/10/29.
+//
+
+import Foundation
+
+class DailyViewModel: ViewModelable {
+  
+  enum Action {
+    case none
+  }
+  
+  func action(_ action: Action) {
+    
+  }
+}

--- a/checky/checky/View/MainView/CalendarView/DailyView/DailyViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/DailyView/DailyViewModel.swift
@@ -13,8 +13,11 @@ class DailyViewModel: ViewModelable {
   @Published var timeEvents: [Event]
   
   @Published var reminders: [Reminder]
-//  @State var dayReminders: [Event]
-//  @State var timeReminders: [Event]
+  @Published var dayReminders: [Reminder]
+  @Published var timeReminders: [Reminder]
+  
+//  @Published var compeletedReminders: [Reminder]
+  
   var eventManager: EventManager
   var reminderManager: ReminderManager
   
@@ -24,8 +27,12 @@ class DailyViewModel: ViewModelable {
        reminderManager: ReminderManager) {
     self.events = events
     self.allDayEvents = events.filter { $0.ekevent.isAllDay == true }
-    self.timeEvents = events.filter { $0.ekevent.isAllDay == false }
+    
     self.reminders = reminders
+    self.dayReminders = reminders.filter { $0.ekreminder.dueDateComponents?.day != nil && $0.ekreminder.dueDateComponents?.hour == nil }
+    self.timeEvents = events.filter { $0.ekevent.isAllDay == false }
+    self.timeReminders = reminders.filter { $0.ekreminder.dueDateComponents?.hour != nil }
+    
     self.eventManager = eventManager
     self.reminderManager = reminderManager
   }

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyCellView.swift
@@ -36,7 +36,11 @@ struct MonthlyCellView: View {
           EventBlockView(event: event)
         }
         
-        ForEach(viewModel.dueDateReminders, id: \.self) { reminder in
+        ForEach(viewModel.filteredHightPriorityDuedateReminder(), id: \.self) { reminder in
+          ReminderBlockView(reminder: reminder)
+        }
+        
+        ForEach(viewModel.filteredHightPriorityClearedReminder(), id: \.self) { reminder in
           ReminderBlockView(reminder: reminder)
         }
       }

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyCellView.swift
@@ -27,22 +27,26 @@ struct MonthlyCellView: View {
               .foregroundColor(Color.basicWhite)
           } else {
             Text(viewModel.dateValue.date.day)
+              .frame(height: 20)
               .font(.caption2)
               .foregroundColor(viewModel.dateValue.isCurrentMonth ? Color.fontMediumGray : Color.fontLightGray)
+              
           }
         }
-        
-        ForEach(viewModel.allEvnets, id: \.self) { event in
-          EventBlockView(event: event)
+        Group {
+          ForEach(viewModel.allEvnets, id: \.self) { event in
+            EventBlockView(event: event)
+          }
+          
+          ForEach(viewModel.filteredHightPriorityDuedateReminder(), id: \.self) { reminder in
+            ReminderBlockView(reminder: reminder)
+          }
+          
+          ForEach(viewModel.filteredHightPriorityClearedReminder(), id: \.self) { reminder in
+            ReminderBlockView(reminder: reminder)
+          }
         }
-        
-        ForEach(viewModel.filteredHightPriorityDuedateReminder(), id: \.self) { reminder in
-          ReminderBlockView(reminder: reminder)
-        }
-        
-        ForEach(viewModel.filteredHightPriorityClearedReminder(), id: \.self) { reminder in
-          ReminderBlockView(reminder: reminder)
-        }
+        .opacity(viewModel.dateValue.isCurrentMonth ? 1.0 : 0.3)
       }
     }
   }

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyCellView.swift
@@ -23,9 +23,11 @@ struct MonthlyCellView: View {
               .fill(Color.fontBlack)
               .frame(width: 20, height: 20)
             Text(viewModel.dateValue.date.day)
+              .font(.caption2)
               .foregroundColor(Color.basicWhite)
           } else {
             Text(viewModel.dateValue.date.day)
+              .font(.caption2)
               .foregroundColor(viewModel.dateValue.isCurrentMonth ? Color.fontMediumGray : Color.fontLightGray)
           }
         }
@@ -47,7 +49,7 @@ struct EventBlockView: View {
   
   var body: some View {
     ZStack(alignment: .leading) {
-      Rectangle()
+      RoundedRectangle(cornerRadius: 2)
         .fill(Color(event.category.cgColor))
         .frame(maxWidth: .infinity)
         .layoutPriority(1)
@@ -55,13 +57,14 @@ struct EventBlockView: View {
       Text(event.ekevent.title)
         .padding(1)
         .lineLimit(1)
-        .font(.caption)
+        .font(.caption2)
         .fontWeight(.semibold)
         .foregroundColor(Color.basicWhite)
         .fixedSize(horizontal: true, vertical: false)
     }
     .frame(height: 16)
     .padding(.vertical, 1.1)
+    .padding(.horizontal, 0.5)
   }
 }
 
@@ -86,7 +89,7 @@ struct ReminderBlockView: View {
           .frame(maxWidth: .infinity)
           .layoutPriority(1)
         Text(reminder.ekreminder.title)
-          .font(.caption)
+          .font(.caption2)
           .foregroundColor(Color.fontDarkBlack)
           .fixedSize(horizontal: true, vertical: false)
       }

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyCellView.swift
@@ -36,7 +36,7 @@ struct MonthlyCellView: View {
           EventBlockView(event: event)
         }
         
-        ForEach(viewModel.allReminders, id: \.self) { reminder in
+        ForEach(viewModel.dueDateReminders, id: \.self) { reminder in
           ReminderBlockView(reminder: reminder)
         }
       }

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyCellView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct MonthlyCellView: View {
-  
   @StateObject var viewModel: MonthlyCellViewModel
   
   var body: some View {

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyCellViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyCellViewModel.swift
@@ -13,15 +13,32 @@ class MonthlyCellViewModel: ObservableObject {
   @Published var dueDateReminders: [Reminder] = []
   @Published var clearedReminders: [Reminder] = []
   
+  let eventManager: EventManager
+  let reminderManager: ReminderManager
+  
   init(
     dateValue: DateValue,
     allEvnets: [Event] = [],
     dueDateReminders: [Reminder] = [],
-    clearedReminders: [Reminder] = []
+    clearedReminders: [Reminder] = [],
+    eventManager: EventManager,
+    reminderManager: ReminderManager
   ) {
     self.dateValue = dateValue
     self.allEvnets = allEvnets
     self.dueDateReminders = dueDateReminders
     self.clearedReminders = clearedReminders
+    
+    self.eventManager = eventManager
+    self.reminderManager = reminderManager
+  }
+  
+  func filteredHightPriorityDuedateReminder() -> [Reminder] {
+    reminderManager.filterHighPriorityTask(dueDateReminders, dateValue.date)
+      .filter { $0.ekreminder.isCompleted == false }
+  }
+  
+  func filteredHightPriorityClearedReminder() -> [Reminder] {
+    return reminderManager.filterHighPriorityTask(clearedReminders, dateValue.date)
   }
 }

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyCellViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyCellViewModel.swift
@@ -10,15 +10,18 @@ import Foundation
 class MonthlyCellViewModel: ObservableObject {
   @Published var dateValue: DateValue
   @Published var allEvnets: [Event] = []
-  @Published var allReminders: [Reminder] = []
+  @Published var dueDateReminders: [Reminder] = []
+  @Published var clearedReminders: [Reminder] = []
   
   init(
     dateValue: DateValue,
     allEvnets: [Event] = [],
-    allReminders: [Reminder] = []
+    dueDateReminders: [Reminder] = [],
+    clearedReminders: [Reminder] = []
   ) {
     self.dateValue = dateValue
     self.allEvnets = allEvnets
-    self.allReminders = allReminders
+    self.dueDateReminders = dueDateReminders
+    self.clearedReminders = clearedReminders
   }
 }

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyStackView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyStackView.swift
@@ -30,7 +30,7 @@ struct MonthlyStackView: View {
                   VStack {
                     DayOfWeekStackView(viewModel: DayOfWeekStackViewModel())
                       .frame(width: geo.size.width, height: 30)
-                    MonthlyView(viewModel: MonthlyViewModel(date: date, eventManager: viewModel.eventManager, reminderManager: viewModel.reminderManager, calendarHelper: viewModel.calendarHelper, moveToWeek: viewModel.moveToWeek))
+                    MonthlyView(viewModel: MonthlyViewModel(date: date, eventManager: viewModel.eventManager, reminderManager: viewModel.reminderManager, calendarHelper: viewModel.calendarHelper))
                       .frame(width: geo.size.width, height: geo.size.height-30)
                   }
                 }

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyStackView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyStackView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct MonthlyStackView: View {
+  @EnvironmentObject var coordinator: Coordinator<checkyRouter>
   @StateObject var viewModel: MonthlyStackViewModel
   
   var body: some View {
@@ -30,6 +31,7 @@ struct MonthlyStackView: View {
                     DayOfWeekStackView(viewModel: DayOfWeekStackViewModel())
                       .frame(width: geo.size.width, height: 30)
                     MonthlyView(viewModel: MonthlyViewModel(date: date, eventManager: viewModel.eventManager, reminderManager: viewModel.reminderManager, calendarHelper: viewModel.calendarHelper))
+                      .environmentObject(coordinator)
                       .frame(width: geo.size.width, height: geo.size.height-30)
                   }
                 }

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyStackView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyStackView.swift
@@ -1,0 +1,63 @@
+//
+//  MonthlyStackView.swift
+//  checky
+//
+//  Created by RED on 2022/10/28.
+//
+
+import SwiftUI
+
+struct MonthlyStackView: View {
+  @StateObject var viewModel: MonthlyStackViewModel
+  
+  var body: some View {
+    VStack(spacing: 1) {
+      HeaderView(viewModel: HeaderViewModel(dateHolder: viewModel.dateHolder, calendarHelper: viewModel.calendarHelper))
+      HStack {
+        Spacer()
+        
+        Button("Weekly") { viewModel.action(.moveToWeekly) }
+          .buttonStyle(ToggleButtonStyle())
+          .padding(.top, 10)
+          .padding(.horizontal, 10)
+      }
+      
+      GeometryReader { geo in
+        VStack {
+            LazyHStack {
+                ForEach(viewModel.pastCurrentFutureDates, id: \.self) { date in
+                    let _ = print(date)
+                  VStack {
+                    DayOfWeekStackView(viewModel: DayOfWeekStackViewModel())
+                      .frame(width: geo.size.width, height: 30)
+                    MonthlyView(viewModel: MonthlyViewModel(date: date, eventManager: viewModel.eventManager, reminderManager: viewModel.reminderManager, calendarHelper: viewModel.calendarHelper, moveToWeek: viewModel.moveToWeek))
+                      .frame(width: geo.size.width, height: geo.size.height-30)
+                  }
+                }
+            }
+          .animation(.easeInOut, value: viewModel.currentOffsetX)
+          .offset(x: viewModel.currentOffsetX)
+          .gesture(DragGesture().onEnded({ gesture in
+
+            if gesture.translation.width > 0 {
+              viewModel.action(.moveToPreviousMonth)
+            }
+
+            if gesture.translation.width < 0 {
+              viewModel.action(.moveToNextMonth)
+            }
+          }))
+          .onChange(of: viewModel.currentIndex) { index in
+            viewModel.action(.onChagnedIndex(index))
+          }
+        }
+      }
+      .background(Color.basicWhite)
+      .cornerRadius(20)
+      .padding(.horizontal, 4)
+      .padding(.top, 10)
+      .padding(.bottom, 10)
+    }
+    .background(Color.backgroundGray)
+  }
+}

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyStackViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyStackViewModel.swift
@@ -70,6 +70,7 @@ class MonthlyStackViewModel: ViewModelable {
   private func moveToPreviousMonth() {
     currentOffsetX += offsetWidth
       currentIndex -= 1
+    dateHolder.date = calendarHelper.minusDate(dateHolder.date)
   }
   
   private func moveToNextMonth() {
@@ -79,7 +80,7 @@ class MonthlyStackViewModel: ViewModelable {
   
   private func onChagnedIndex(_ changedIndex: Int) {
     if changedIndex == 0 {
-      dateHolder.date = calendarHelper.minusDate(dateHolder.date)
+//      dateHolder.date = calendarHelper.minusDate(dateHolder.date)
       currentOffsetX = -offsetWidth
       currentIndex = 1
     }

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyStackViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyStackViewModel.swift
@@ -1,0 +1,94 @@
+//
+//  MonthlyStackViewModel.swift
+//  checky
+//
+//  Created by RED on 2022/10/28.
+//
+
+import Foundation
+
+class MonthlyStackViewModel: ViewModelable {
+  let eventManager: EventManager
+  let reminderManager: ReminderManager
+  let calendarHelper: CalendarCanDo
+  let offsetWidth: CGFloat
+  var moveToWeek: () -> ()
+
+  @Published var dateHolder: DateHolder
+  @Published var events: [Event]
+  @Published var reminders: [Reminder]
+  @Published var currentOffsetX: CGFloat
+  
+  @Published var currentIndex: Int = 1
+    
+  init(
+    dateHolder: DateHolder,
+    eventManager: EventManager,
+    reminderManager: ReminderManager,
+    calendarHelper: CalendarCanDo,
+    offsetWidth: CGFloat,
+    events: [Event] = [],
+    reminders: [Reminder] = [],
+    moveToWeek: @escaping () -> (),
+    currentIndex: Int = 1
+  ) {
+    self.moveToWeek = moveToWeek
+    self.dateHolder = dateHolder
+    self.eventManager = eventManager
+    self.reminderManager = reminderManager
+    self.calendarHelper = calendarHelper
+    self.events = events
+    self.reminders = reminders
+    self.offsetWidth = offsetWidth
+    
+    self.currentOffsetX = -CGFloat(currentIndex) * offsetWidth
+  }
+  
+  var pastCurrentFutureDates: [Date] {
+    return calendarHelper.extractPastCurrentFutureDates(dateHolder.date)
+  }
+  
+  enum Action {
+    case moveToWeekly
+    case moveToPreviousMonth
+    case moveToNextMonth
+    case onChagnedIndex(Int)
+  }
+  
+  func action(_ action: Action) {
+    switch action {
+      case .moveToWeekly:
+        moveToWeek()
+      case .moveToPreviousMonth:
+        moveToPreviousMonth()
+      case.moveToNextMonth:
+        moveToNextMonth()
+      case .onChagnedIndex(let changedIndex):
+        onChagnedIndex(changedIndex)
+    }
+  }
+  
+  private func moveToPreviousMonth() {
+    currentOffsetX += offsetWidth
+      currentIndex -= 1
+  }
+  
+  private func moveToNextMonth() {
+    currentOffsetX -= offsetWidth
+    currentIndex += 1
+  }
+  
+  private func onChagnedIndex(_ changedIndex: Int) {
+    if changedIndex == 0 {
+      dateHolder.date = calendarHelper.minusDate(dateHolder.date)
+      currentOffsetX = -offsetWidth
+      currentIndex = 1
+    }
+    
+    if changedIndex == 2 {
+      dateHolder.date = calendarHelper.plusDate(dateHolder.date)
+      currentOffsetX = -offsetWidth
+      currentIndex = 1
+    }
+  }
+}

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyStackViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyStackViewModel.swift
@@ -18,8 +18,7 @@ class MonthlyStackViewModel: ViewModelable {
   @Published var events: [Event]
   @Published var reminders: [Reminder]
   @Published var currentOffsetX: CGFloat
-  
-  @Published var currentIndex: Int = 1
+  @Published var currentIndex: Int
     
   init(
     dateHolder: DateHolder,
@@ -40,7 +39,7 @@ class MonthlyStackViewModel: ViewModelable {
     self.events = events
     self.reminders = reminders
     self.offsetWidth = offsetWidth
-    
+    self.currentIndex = currentIndex
     self.currentOffsetX = -CGFloat(currentIndex) * offsetWidth
   }
   

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyStackViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyStackViewModel.swift
@@ -8,17 +8,17 @@
 import Foundation
 
 class MonthlyStackViewModel: ViewModelable {
-  let eventManager: EventManager
-  let reminderManager: ReminderManager
-  let calendarHelper: CalendarCanDo
-  let offsetWidth: CGFloat
-  var moveToWeek: () -> ()
-
   @Published var dateHolder: DateHolder
   @Published var events: [Event]
   @Published var reminders: [Reminder]
   @Published var currentOffsetX: CGFloat
   @Published var currentIndex: Int
+  
+  let eventManager: EventManager
+  let reminderManager: ReminderManager
+  let calendarHelper: CalendarCanDo
+  let offsetWidth: CGFloat
+  var moveToWeek: () -> ()
     
   init(
     dateHolder: DateHolder,

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
@@ -32,7 +32,7 @@ struct MonthlyView: View {
                                                           eventManager: viewModel.eventManager,
                                                           reminderManager: viewModel.reminderManager))
           .onTapGesture {
-            coordinator.show(.daily(events, reminders, clearedReminders, viewModel.eventManager, viewModel.reminderManager))
+            coordinator.show(.daily(value.date, events, reminders, clearedReminders, viewModel.eventManager, viewModel.reminderManager))
             print("tabbed!!!chell")
           }
           

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 
-
-
 struct MonthlyView: View {
   @EnvironmentObject var coordinator: Coordinator<checkyRouter>
   @StateObject var viewModel: MonthlyViewModel

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
@@ -32,7 +32,7 @@ struct MonthlyView: View {
                                                           eventManager: viewModel.eventManager,
                                                           reminderManager: viewModel.reminderManager))
           .onTapGesture {
-            coordinator.show(.daily(events, reminders, clearedReminders, viewModel.reminderManager))
+            coordinator.show(.daily(events, reminders, clearedReminders, viewModel.eventManager, viewModel.reminderManager))
             print("tabbed!!!chell")
           }
           

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
@@ -28,7 +28,7 @@ struct MonthlyView: View {
                                                           allEvnets: events,
                                                           allReminders: reminders))
           .onTapGesture {
-            coordinator.show(.daily(events))
+            coordinator.show(.daily(events, reminders, viewModel.reminderManager))
             print("tabbed!!!chell")
           }
           

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
@@ -7,78 +7,33 @@
 
 import SwiftUI
 
+
+
 struct MonthlyView: View {
   @StateObject var viewModel: MonthlyViewModel
   
   var body: some View {
-    VStack(spacing: 1) {
-      HeaderView(viewModel: HeaderViewModel(dateHolder: viewModel.dateHolder, calendarHelper: viewModel.calendarHelper))
-      HStack {
-        Spacer()
-        
-        Button("Weekly") { viewModel.action(.moveToWeekly) }
-          .buttonStyle(ToggleButtonStyle())
-          .padding(.top, 10)
-          .padding(.horizontal, 10)
-      }
+    GeometryReader { geo in
+      let columns = Array(repeating: GridItem(.flexible(), spacing: 0, alignment: nil), count: 7)
+      let columnsCount: CGFloat = viewModel.gridCloumnsCount
       
-      VStack(spacing: 0) {
-        
-        DayOfWeekStackView(viewModel: DayOfWeekStackViewModel())
-        
-        MonthlyGrid
+      LazyVGrid(columns: columns, spacing: 0) {
+        ForEach(viewModel.allDatesForDisplay) { value in
+          
+          let events = viewModel.filteredEvent(value.date)
+          let reminders = viewModel.filteredReminder(value.date)
+          
+          MonthlyCellView(viewModel: MonthlyCellViewModel(dateValue: value,
+                                                          allEvnets: events,
+                                                          allReminders: reminders))
+          
+          .frame(width: geo.size.width / 7, height: geo.size.height / columnsCount)
+        }
       }
-      .background(Color.basicWhite)
-      .cornerRadius(20)
-      .padding(.horizontal, 4)
-      .padding(.vertical, 25)
     }
-    .background(Color.backgroundGray)
-    .onChange(of: viewModel.dateHolder.date) { _ in
-      viewModel.action(.onChangeDate)
-      }
+    .frame(maxHeight: .infinity)
     .onAppear {
       viewModel.action(.actionOnAppear)
     }
-  }
-}
-
-extension MonthlyView {
-  var MonthlyGrid: some View {
-    let columns = Array(repeating: GridItem(.flexible(), spacing: 0, alignment: nil), count: 7)
-    
-    let columnsCount: CGFloat = viewModel.gridCloumnsCount
-    
-    var body: some View {
-      GeometryReader { geo in
-        LazyVGrid(columns: columns, spacing: 0) {
-          ForEach(viewModel.allDatesForDisplay) { value in
-            
-            let events = viewModel.filteredEvent(value.date)
-            let reminders = viewModel.filteredReminder(value.date)
-            
-            MonthlyCellView(viewModel: MonthlyCellViewModel(dateValue: value,
-                                                            allEvnets: events,
-                                                            allReminders: reminders))
-      
-            .frame(width: geo.size.width / 7, height: geo.size.height / columnsCount)
-          }
-        }
-      }
-      .frame(maxHeight: .infinity)
-      .gesture(
-        DragGesture()
-          .onChanged { value in
-            viewModel.currentOffsetX = value.translation
-          }
-          .onEnded { value in
-            viewModel.action(.dragGestur)
-            withAnimation(.linear(duration: 0.4)) {
-              viewModel.action(.resetCurrentOffsetX)
-            }
-          }
-      )
-    }
-    return body
   }
 }

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
@@ -23,12 +23,14 @@ struct MonthlyView: View {
           
           let events = viewModel.filteredEvent(value.date)
           let reminders = viewModel.filteredReminder(value.date)
+          let clearedReminders = viewModel.filteredClearedReminder(value.date)
           
           MonthlyCellView(viewModel: MonthlyCellViewModel(dateValue: value,
                                                           allEvnets: events,
-                                                          allReminders: reminders))
+                                                          dueDateReminders: reminders,
+                                                          clearedReminders: clearedReminders))
           .onTapGesture {
-            coordinator.show(.daily(events, reminders, viewModel.reminderManager))
+            coordinator.show(.daily(events, reminders, clearedReminders, viewModel.reminderManager))
             print("tabbed!!!chell")
           }
           

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
@@ -35,8 +35,8 @@ struct MonthlyView: View {
             coordinator.show(.daily(value.date, events, reminders, clearedReminders, viewModel.eventManager, viewModel.reminderManager))
             print("tabbed!!!chell")
           }
-          
-          .frame(width: geo.size.width / 7, height: geo.size.height / columnsCount)
+          .frame(width: geo.size.width / 7, height: geo.size.height / columnsCount, alignment: .top)
+          .clipped()
         }
       }
     }

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
@@ -28,7 +28,9 @@ struct MonthlyView: View {
           MonthlyCellView(viewModel: MonthlyCellViewModel(dateValue: value,
                                                           allEvnets: events,
                                                           dueDateReminders: reminders,
-                                                          clearedReminders: clearedReminders))
+                                                          clearedReminders: clearedReminders,
+                                                          eventManager: viewModel.eventManager,
+                                                          reminderManager: viewModel.reminderManager))
           .onTapGesture {
             coordinator.show(.daily(events, reminders, clearedReminders, viewModel.reminderManager))
             print("tabbed!!!chell")

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 
 struct MonthlyView: View {
+  @EnvironmentObject var coordinator: Coordinator<checkyRouter>
   @StateObject var viewModel: MonthlyViewModel
   
   var body: some View {
@@ -26,6 +27,10 @@ struct MonthlyView: View {
           MonthlyCellView(viewModel: MonthlyCellViewModel(dateValue: value,
                                                           allEvnets: events,
                                                           allReminders: reminders))
+          .onTapGesture {
+            coordinator.show(.daily(events))
+            print("tabbed!!!chell")
+          }
           
           .frame(width: geo.size.width / 7, height: geo.size.height / columnsCount)
         }

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyViewModel.swift
@@ -9,13 +9,13 @@ import SwiftUI
 import Combine
 
 class MonthlyViewModel: ViewModelable {
-  let eventManager: EventManager
-  let reminderManager: ReminderManager
-  let calendarHelper: CalendarCanDo
-
   @Published var date: Date
   @Published var events: [Event]
   @Published var reminders: [Reminder]
+  
+  let eventManager: EventManager
+  let reminderManager: ReminderManager
+  let calendarHelper: CalendarCanDo
     
   init(
     date: Date,

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyViewModel.swift
@@ -78,6 +78,10 @@ class MonthlyViewModel: ViewModelable {
     reminderManager.filterTask(reminders, date)
   }
   
+  func filteredClearedReminder(_ date: Date) -> [Reminder] {
+    reminderManager.filterClearTask(reminders, date)
+  }
+  
   var gridCloumnsCount: CGFloat {
     return calendarHelper.extractDates(date).count > 35 ? CGFloat(6) : CGFloat(5)
   }

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyViewModel.swift
@@ -14,13 +14,13 @@ class MonthlyViewModel: ViewModelable {
   let calendarHelper: CalendarCanDo
   var moveToWeek: () -> ()
 
-  @Published var dateHolder: DateHolder
+  @Published var date: Date
   @Published var events: [Event]
   @Published var reminders: [Reminder]
   @Published var currentOffsetX: CGSize
     
   init(
-    dateHolder: DateHolder,
+    date: Date,
     eventManager: EventManager,
     reminderManager: ReminderManager,
     calendarHelper: CalendarCanDo,
@@ -30,7 +30,7 @@ class MonthlyViewModel: ViewModelable {
     moveToWeek: @escaping () -> ()
   ) {
     self.moveToWeek = moveToWeek
-    self.dateHolder = dateHolder
+    self.date = date
     self.eventManager = eventManager
     self.reminderManager = reminderManager
     self.calendarHelper = calendarHelper
@@ -42,8 +42,8 @@ class MonthlyViewModel: ViewModelable {
   enum Action {
     case actionOnAppear
     case onChangeDate
-    case dragGestur
-    case resetCurrentOffsetX
+//    case dragGestur
+//    case resetCurrentOffsetX
     case moveToWeekly
   }
   
@@ -56,10 +56,10 @@ class MonthlyViewModel: ViewModelable {
       case .onChangeDate:
         fetchEvents()
         fetchReminder()
-      case .dragGestur:
-        dragGestureonEnded()
-      case .resetCurrentOffsetX:
-        resetCurrentOffsetX()
+//      case .dragGestur:
+//        dragGestureonEnded()
+//      case .resetCurrentOffsetX:
+//        resetCurrentOffsetX()
       case .moveToWeekly:
         moveToWeek()
     }
@@ -71,7 +71,7 @@ class MonthlyViewModel: ViewModelable {
   }
   
   func fetchEvents() {
-    eventManager.getAllTaskforThisMonth(date: dateHolder.date, completionHandler: { [weak self] eventList in
+    eventManager.getAllTaskforThisMonth(date: date, completionHandler: { [weak self] eventList in
       DispatchQueue.main.async {
         self?.events = eventList
       }
@@ -79,7 +79,7 @@ class MonthlyViewModel: ViewModelable {
   }
   
   func fetchReminder() {
-    reminderManager.getAllTaskforThisMonth(date: dateHolder.date) { [weak self] reminderList in
+    reminderManager.getAllTaskforThisMonth(date: date) { [weak self] reminderList in
       DispatchQueue.main.async {
         self?.reminders = reminderList
       }
@@ -87,7 +87,7 @@ class MonthlyViewModel: ViewModelable {
   }
   
   var allDatesForDisplay: [DateValue] {
-    return calendarHelper.extractDates(dateHolder.date)
+    return calendarHelper.extractDates(date)
   }
   
   func filteredEvent(_ date: Date) -> [Event] {
@@ -99,18 +99,18 @@ class MonthlyViewModel: ViewModelable {
   }
   
   var gridCloumnsCount: CGFloat {
-    return calendarHelper.extractDates(dateHolder.date).count > 35 ? CGFloat(6) : CGFloat(5)
+    return calendarHelper.extractDates(date).count > 35 ? CGFloat(6) : CGFloat(5)
   }
   
-  func dragGestureonEnded() {
-    guard currentOffsetX.width < 0 else {
-      dateHolder.date = calendarHelper.minusDate(dateHolder.date)
-      return
-    }
-    dateHolder.date = calendarHelper.plusDate(dateHolder.date)
-  }
+//  func dragGestureonEnded() {
+//    guard currentOffsetX.width < 0 else {
+//      date = calendarHelper.minusDate(date)
+//      return
+//    }
+//      date = calendarHelper.plusDate(date)
+//  }
   
-  func resetCurrentOffsetX() {
-    currentOffsetX = .zero
-  }
+//  func resetCurrentOffsetX() {
+//    currentOffsetX = .zero
+//  }
 }

--- a/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/MonthlyView/MonthlyDateView/MonthlyViewModel.swift
@@ -12,12 +12,10 @@ class MonthlyViewModel: ViewModelable {
   let eventManager: EventManager
   let reminderManager: ReminderManager
   let calendarHelper: CalendarCanDo
-  var moveToWeek: () -> ()
 
   @Published var date: Date
   @Published var events: [Event]
   @Published var reminders: [Reminder]
-  @Published var currentOffsetX: CGSize
     
   init(
     date: Date,
@@ -26,48 +24,30 @@ class MonthlyViewModel: ViewModelable {
     calendarHelper: CalendarCanDo,
     events: [Event] = [],
     reminders: [Reminder] = [],
-    currentOffsetX: CGSize = .zero,
-    moveToWeek: @escaping () -> ()
+    currentOffsetX: CGSize = .zero
   ) {
-    self.moveToWeek = moveToWeek
     self.date = date
     self.eventManager = eventManager
     self.reminderManager = reminderManager
     self.calendarHelper = calendarHelper
     self.events = events
     self.reminders = reminders
-    self.currentOffsetX = currentOffsetX
   }
   
   enum Action {
     case actionOnAppear
     case onChangeDate
-//    case dragGestur
-//    case resetCurrentOffsetX
-    case moveToWeekly
   }
   
   func action(_ action: Action) {
     switch action {
       case .actionOnAppear:
-        getPermission()
         fetchEvents()
         fetchReminder()
       case .onChangeDate:
         fetchEvents()
         fetchReminder()
-//      case .dragGestur:
-//        dragGestureonEnded()
-//      case .resetCurrentOffsetX:
-//        resetCurrentOffsetX()
-      case .moveToWeekly:
-        moveToWeek()
     }
-  }
-  
-  
-  func getPermission() {
-    eventManager.getPermission()
   }
   
   func fetchEvents() {
@@ -101,16 +81,5 @@ class MonthlyViewModel: ViewModelable {
   var gridCloumnsCount: CGFloat {
     return calendarHelper.extractDates(date).count > 35 ? CGFloat(6) : CGFloat(5)
   }
-  
-//  func dragGestureonEnded() {
-//    guard currentOffsetX.width < 0 else {
-//      date = calendarHelper.minusDate(date)
-//      return
-//    }
-//      date = calendarHelper.plusDate(date)
-//  }
-  
-//  func resetCurrentOffsetX() {
-//    currentOffsetX = .zero
-//  }
+
 }

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyCellView.swift
@@ -52,12 +52,16 @@ struct WeeklyCellView: View {
             }
             
             VStack(alignment: .leading, spacing: 2) {
-              ForEach(viewModel.allReminders, id: \.self) { reminder in
+              ForEach(viewModel.filteredHightPriorityDuedateReminder(), id: \.self) { reminder in
+                WeeklyReminderBlockView(reminder: reminder)
+                  .frame(height: 14)
+              }
+              
+              ForEach(viewModel.filteredHightPriorityClearedReminder(), id: \.self) { reminder in
                 WeeklyReminderBlockView(reminder: reminder)
                   .frame(height: 14)
               }
             }
-            
           }
           .padding(.horizontal, 6)
         }

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyCellView.swift
@@ -15,38 +15,49 @@ struct WeeklyCellView: View {
     ZStack(alignment: .topLeading) {
       
       RoundedRectangle(cornerRadius: 10)
-        .fill(Color("basicWhite"))
+        .fill(Color.basicWhite)
       
-      VStack(alignment: .leading) {
+      VStack(alignment: .leading, spacing: 4) {
         HStack {
           Text(viewModel.dateValue.date.dayOfWeek)
+            .font(.caption2)
             .foregroundColor(.black.opacity(0.5))
           if Calendar.current.isDateInToday(viewModel.dateValue.date) {
             ZStack {
               Circle()
-                .fill(Color("fontBlack"))
-                .frame(width: 30, height: 30)
+                .fill(Color.fontBlack)
+                .frame(width: 20, height: 20)
               Text(viewModel.dateValue.date.day)
-                .foregroundColor(Color("basicWhite"))
+                .font(.caption2)
+                .foregroundColor(Color.basicWhite)
             }
             
           } else {
             Text(viewModel.dateValue.date.day)
+              .font(.caption2)
+              .foregroundColor(Color.fontBlack)
           }
         }
-        .padding(6)
+        .padding(.top, 10)
+        .padding(.horizontal, 10)
         
         ScrollView {
-          VStack {
-            ForEach(viewModel.allEvnets, id: \.self) { event in
-              WeeklyEventBlockView(event: event)
-                .frame(height: 20)
+          VStack(alignment: .leading, spacing: 6) {
+            
+            VStack(alignment: .leading, spacing: 2) {
+              ForEach(viewModel.allEvnets, id: \.self) { event in
+                WeeklyEventBlockView(event: event)
+                  .frame(height: 20)
+              }
             }
             
-            ForEach(viewModel.allReminders, id: \.self) { reminder in
-              ReminderBlockView(reminder: reminder)
-                .frame(height: 14)
+            VStack(alignment: .leading, spacing: 2) {
+              ForEach(viewModel.allReminders, id: \.self) { reminder in
+                WeeklyReminderBlockView(reminder: reminder)
+                  .frame(height: 14)
+              }
             }
+            
           }
           .padding(.horizontal, 6)
         }
@@ -71,6 +82,7 @@ struct WeeklyEventBlockView: View {
         .fontWeight(.semibold)
         .foregroundColor(Color.basicWhite)
         .fixedSize(horizontal: true, vertical: false)
+        .padding(.horizontal, 4)
     }
   }
 }
@@ -79,7 +91,7 @@ struct WeeklyReminderBlockView: View {
   let reminder: Reminder
   
   var body: some View {
-    HStack() {
+    HStack(spacing: 4) {
       ZStack {
         
         Circle()
@@ -91,20 +103,11 @@ struct WeeklyReminderBlockView: View {
           .opacity(reminder.ekreminder.isCompleted ? 1.0 : 0.0)
       }
       
-      ZStack(alignment: .leading) {
-        Rectangle()
-          .fill(Color.basicWhite)
-          .frame(maxWidth: .infinity)
-          .layoutPriority(1)
-        Text(reminder.ekreminder.title)
-          .font(.caption)
-          .foregroundColor(Color.fontDarkBlack)
-          .fixedSize(horizontal: true, vertical: false)
-        Text(reminder.ekreminder.notes ?? "")
-          .font(.caption)
-          .foregroundColor(Color.fontDarkBlack)
-          .fixedSize(horizontal: true, vertical: false)
-      }
+      Text(reminder.ekreminder.title)
+        .font(.caption)
+        .foregroundColor(Color.fontDarkBlack)
+        .fixedSize(horizontal: true, vertical: false)
     }
+    .padding(.horizontal, 2)
   }
 }

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyCellView.swift
@@ -21,20 +21,15 @@ struct WeeklyCellView: View {
           Text(viewModel.dateValue.date.dayOfWeek)
             .font(.caption2)
             .foregroundColor(.black.opacity(0.5))
-          if Calendar.current.isDateInToday(viewModel.dateValue.date) {
-            ZStack {
+          ZStack {
+            if Calendar.current.isDateInToday(viewModel.dateValue.date) {
               Circle()
                 .fill(Color.fontBlack)
                 .frame(width: 20, height: 20)
-              Text(viewModel.dateValue.date.day)
-                .font(.caption2)
-                .foregroundColor(Color.basicWhite)
             }
-            
-          } else {
             Text(viewModel.dateValue.date.day)
               .font(.caption2)
-              .foregroundColor(Color.fontBlack)
+              .foregroundColor(Calendar.current.isDateInToday(viewModel.dateValue.date) ? Color.fontBlack : Color.basicWhite)
           }
         }
         .padding(.top, 10)

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyCellView.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyCellView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct WeeklyCellView: View {
-  
   @StateObject var viewModel: WeeklyCellViewModel
   
   var body: some View {

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyCellViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyCellViewModel.swift
@@ -10,15 +10,35 @@ import Foundation
 class WeeklyCellViewModel: ObservableObject {
   @Published var dateValue: DateValue
   @Published var allEvnets: [Event] = []
-  @Published var allReminders: [Reminder] = []
+  @Published var dueDateReminders: [Reminder] = []
+  @Published var clearedReminders: [Reminder] = []
+  
+  let eventManager: EventManager
+  let reminderManager: ReminderManager
   
   init(
     dateValue: DateValue,
     allEvnets: [Event] = [],
-    allReminders: [Reminder] = []
+    dueDateReminders: [Reminder] = [],
+    clearedReminders: [Reminder] = [],
+    eventManager: EventManager,
+    reminderManager: ReminderManager
   ) {
     self.dateValue = dateValue
     self.allEvnets = allEvnets
-    self.allReminders = allReminders
+    self.dueDateReminders = dueDateReminders
+    self.clearedReminders = clearedReminders
+    
+    self.eventManager = eventManager
+    self.reminderManager = reminderManager
+  }
+  
+  func filteredHightPriorityDuedateReminder() -> [Reminder] {
+    reminderManager.filterHighPriorityTask(dueDateReminders, dateValue.date)
+      .filter { $0.ekreminder.isCompleted == false }
+  }
+  
+  func filteredHightPriorityClearedReminder() -> [Reminder] {
+    return reminderManager.filterHighPriorityTask(clearedReminders, dateValue.date)
   }
 }

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackView.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackView.swift
@@ -23,7 +23,9 @@ struct WeeklyStackView: View {
           .padding(.horizontal, 10)
       }
       
-      GeometryReader { geo in
+      ZStack(alignment: .topLeading) {
+        
+        GeometryReader { geo in
           LazyHStack {
             ForEach(viewModel.pastCurrentFutureDates, id: \.self) { date in
               WeeklyView(viewModel: WeeklyViewModel(date: date, eventManager: viewModel.eventManager, reminderManager: viewModel.reminderManager, calendarHelper: viewModel.calendarHelper))
@@ -33,11 +35,11 @@ struct WeeklyStackView: View {
           .animation(.easeInOut, value: viewModel.currentOffsetX)
           .offset(x: viewModel.currentOffsetX-8)
           .gesture(DragGesture().onEnded({ gesture in
-
+            
             if gesture.translation.width > 0 {
               viewModel.action(.moveToPreviousWeek)
             }
-
+            
             if gesture.translation.width < 0 {
               viewModel.action(.moveToNextWeek)
             }
@@ -45,8 +47,48 @@ struct WeeklyStackView: View {
           .onChange(of: viewModel.currentIndex) { index in
             viewModel.action(.onChagnedIndex(index))
           }
+          
+          VStack(spacing: 0) {
+            DayOfWeekStackView(viewModel: DayOfWeekStackViewModel())
+              .padding(.horizontal, 16)
+            miniCalendarView
+          }
+          .frame(width: geo.size.width/2, height: geo.size.height/4)
+          .background(Color.backgroundGray)
+          
+        }
+        
       }
+      
     }
     .background(Color.backgroundGray)
+  }
+}
+
+extension WeeklyStackView {
+  var miniCalendarView: some View {
+    GeometryReader { geo in
+      let columns = Array(repeating: GridItem(.flexible(), spacing: 0, alignment: nil), count: 7)
+      ZStack(alignment: .top) {
+        RoundedRectangle(cornerRadius: 4)
+          .fill(Color.backgroundLightGray)
+          .padding(.horizontal, 10)
+          .frame(height: 16, alignment: .center)
+          .frame(maxWidth: .infinity)
+          .offset(y: viewModel.minimunCalendarWeekheight)
+          .animation(.easeInOut, value: viewModel.minimunCalendarWeekheight)
+        
+        LazyVGrid(columns: columns, spacing: 0) {
+          ForEach(viewModel.extractMonthDates()) { value in
+            
+            Text(value.date.day)
+              .font(.caption2)
+              .foregroundColor(value.isCurrentMonth ? Color.fontBlack : Color.fontMediumGray)
+              .frame(width: 20, height: 16, alignment: .center)
+          }
+        }
+        .padding(.horizontal)
+      }
+    }
   }
 }

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackView.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackView.swift
@@ -54,13 +54,10 @@ struct WeeklyStackView: View {
               .padding(.horizontal, 16)
             miniCalendarView
           }
-          .frame(width: geo.size.width/2, height: geo.size.height/4)
+          .frame(width: geo.size.width / 2, height: geo.size.height / 4)
           .background(Color.backgroundGray)
-          
         }
-        
       }
-      
     }
     .background(Color.backgroundGray)
   }

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackView.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct WeeklyStackView: View {
+  @EnvironmentObject var coordinator: Coordinator<checkyRouter>
   @StateObject var viewModel: WeeklyStackViewModel
   
   var body: some View {

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackView.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackView.swift
@@ -26,31 +26,27 @@ struct WeeklyStackView: View {
       GeometryReader { geo in
           LazyHStack {
             ForEach(viewModel.pastCurrentFutureDates, id: \.self) { date in
-              WeeklyView(viewModel: WeeklyViewModel(date: date, eventManager: viewModel.eventManager, reminderManager: viewModel.reminderManager, calendarHelper: viewModel.calendarHelper, moveToMonthly: viewModel.moveToMonthly))
+              WeeklyView(viewModel: WeeklyViewModel(date: date, eventManager: viewModel.eventManager, reminderManager: viewModel.reminderManager, calendarHelper: viewModel.calendarHelper))
                 .frame(width: geo.size.width, height: geo.size.height)
             }
           }
           .animation(.easeInOut, value: viewModel.currentOffsetX)
-          .offset(x: viewModel.currentOffsetX)
+          .offset(x: viewModel.currentOffsetX-8)
           .gesture(DragGesture().onEnded({ gesture in
 
             if gesture.translation.width > 0 {
-              viewModel.action(.moveToPreviousMonth)
+              viewModel.action(.moveToPreviousWeek)
             }
 
             if gesture.translation.width < 0 {
-              viewModel.action(.moveToNextMonth)
+              viewModel.action(.moveToNextWeek)
             }
           }))
           .onChange(of: viewModel.currentIndex) { index in
             viewModel.action(.onChagnedIndex(index))
           }
       }
-//      Spacer()
     }
     .background(Color.backgroundGray)
-    .onAppear {
-      viewModel.action(.actionOnAppear)
-    }
   }
 }

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackView.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackView.swift
@@ -1,39 +1,35 @@
 //
-//  MonthlyStackView.swift
+//  WeeklyStackView.swift
 //  checky
 //
-//  Created by RED on 2022/10/28.
+//  Created by RED on 2022/10/29.
 //
 
 import SwiftUI
 
-struct MonthlyStackView: View {
-  @StateObject var viewModel: MonthlyStackViewModel
+struct WeeklyStackView: View {
+  @StateObject var viewModel: WeeklyStackViewModel
   
   var body: some View {
     VStack(spacing: 1) {
       HeaderView(viewModel: HeaderViewModel(dateHolder: viewModel.dateHolder, calendarHelper: viewModel.calendarHelper))
+      
       HStack {
         Spacer()
         
-        Button("Weekly") { viewModel.action(.moveToWeekly) }
+        Button("Monthly") { viewModel.action(.moveToMonthly) }
           .buttonStyle(ToggleButtonStyle())
           .padding(.top, 10)
           .padding(.horizontal, 10)
       }
       
       GeometryReader { geo in
-        VStack {
-            LazyHStack {
-                ForEach(viewModel.pastCurrentFutureDates, id: \.self) { date in
-                  VStack {
-                    DayOfWeekStackView(viewModel: DayOfWeekStackViewModel())
-                      .frame(width: geo.size.width, height: 30)
-                    MonthlyView(viewModel: MonthlyViewModel(date: date, eventManager: viewModel.eventManager, reminderManager: viewModel.reminderManager, calendarHelper: viewModel.calendarHelper))
-                      .frame(width: geo.size.width, height: geo.size.height-30)
-                  }
-                }
+          LazyHStack {
+            ForEach(viewModel.pastCurrentFutureDates, id: \.self) { date in
+              WeeklyView(viewModel: WeeklyViewModel(date: date, eventManager: viewModel.eventManager, reminderManager: viewModel.reminderManager, calendarHelper: viewModel.calendarHelper, moveToMonthly: viewModel.moveToMonthly))
+                .frame(width: geo.size.width, height: geo.size.height)
             }
+          }
           .animation(.easeInOut, value: viewModel.currentOffsetX)
           .offset(x: viewModel.currentOffsetX)
           .gesture(DragGesture().onEnded({ gesture in
@@ -49,14 +45,12 @@ struct MonthlyStackView: View {
           .onChange(of: viewModel.currentIndex) { index in
             viewModel.action(.onChagnedIndex(index))
           }
-        }
       }
-      .background(Color.basicWhite)
-      .cornerRadius(20)
-      .padding(.horizontal, 4)
-      .padding(.top, 10)
-      .padding(.bottom, 10)
+//      Spacer()
     }
     .background(Color.backgroundGray)
+    .onAppear {
+      viewModel.action(.actionOnAppear)
+    }
   }
 }

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackViewModel.swift
@@ -51,11 +51,9 @@ class WeeklyStackViewModel: ViewModelable {
   
   enum Action {
     case actionOnAppear
-    case dragGestur
-    case resetCurrentOffsetY
     case moveToMonthly
-    case moveToPreviousMonth
-    case moveToNextMonth
+    case moveToPreviousWeek
+    case moveToNextWeek
     case onChagnedIndex(Int)
   }
   
@@ -63,17 +61,12 @@ class WeeklyStackViewModel: ViewModelable {
     switch action {
     case .actionOnAppear:
       onAppear()
-    case .dragGestur:
-        print("drag")
-//      dragGestureonEnded()
-    case .resetCurrentOffsetY:
-        print("drag")
     case .moveToMonthly:
       moveToMonthly()
-      case .moveToPreviousMonth:
-        moveToPreviousMonth()
-      case .moveToNextMonth:
-        moveToNextMonth()
+      case .moveToPreviousWeek:
+        moveToPreviousWeek()
+      case .moveToNextWeek:
+        moveToNextWeek()
       case .onChagnedIndex(let index):
         onChagnedIndex(index)
     }
@@ -121,12 +114,12 @@ class WeeklyStackViewModel: ViewModelable {
     return CGFloat(calendarHelper.extractDates(dateHolder.date).count + 1)
   }
 
-  private func moveToPreviousMonth() {
+  private func moveToPreviousWeek() {
     currentOffsetX += offsetWidth
       currentIndex -= 1
   }
   
-  private func moveToNextMonth() {
+  private func moveToNextWeek() {
     currentOffsetX -= offsetWidth
     currentIndex += 1
   }

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackViewModel.swift
@@ -8,16 +8,15 @@
 import SwiftUI
 
 class WeeklyStackViewModel: ViewModelable {
+  @Published var dateHolder: DateHolder
+  @Published var currentOffsetX: CGFloat
+  @Published var currentIndex: Int
+  
   let eventManager: EventManager
   let reminderManager: ReminderManager
   let calendarHelper: CalendarCanDo
   let offsetWidth: CGFloat
   var moveToMonthly: () -> ()
-  
-  @Published var dateHolder: DateHolder
-  
-  @Published var currentOffsetX: CGFloat
-  @Published var currentIndex: Int
   
   init(
     dateHolder: DateHolder,
@@ -115,6 +114,4 @@ class WeeklyStackViewModel: ViewModelable {
   func extractMonthDates() -> [DateValue] {
     calendarHelper.extractMonthDates(dateHolder.date)
   }
-  
-
 }

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackViewModel.swift
@@ -1,0 +1,147 @@
+//
+//  WeeklyStackViewModel.swift
+//  checky
+//
+//  Created by RED on 2022/10/29.
+//
+
+import SwiftUI
+
+class WeeklyStackViewModel: ViewModelable {
+  let eventManager: EventManager
+  let reminderManager: ReminderManager
+  let calendarHelper: CalendarCanDo
+  let offsetWidth: CGFloat
+  var moveToMonthly: () -> ()
+  
+  @Published var dateHolder: DateHolder
+  @Published var events: [Event]
+  @Published var reminders: [Reminder]
+  
+  @Published var currentOffsetX: CGFloat
+  @Published var currentIndex: Int
+  
+  init(
+    dateHolder: DateHolder,
+    eventManager: EventManager,
+    reminderManager: ReminderManager,
+    calendarHelper: CalendarCanDo,
+    events: [Event] = [],
+    reminders: [Reminder] = [],
+    offsetWidth: CGFloat,
+    currentIndex: Int = 1,
+    moveToMonthly: @escaping () -> ()
+  ) {
+    self.moveToMonthly = moveToMonthly
+    self.dateHolder = dateHolder
+    self.eventManager = eventManager
+    self.reminderManager = reminderManager
+    self.calendarHelper = calendarHelper
+    self.events = events
+    self.reminders = reminders
+    self.offsetWidth = offsetWidth
+    self.currentIndex = currentIndex
+    
+    self.currentOffsetX = -CGFloat(currentIndex) * offsetWidth
+  }
+  
+  var pastCurrentFutureDates: [Date] {
+    return calendarHelper.extractPastCurrentFutureDates(dateHolder.date)
+  }
+  
+  enum Action {
+    case actionOnAppear
+    case dragGestur
+    case resetCurrentOffsetY
+    case moveToMonthly
+    case moveToPreviousMonth
+    case moveToNextMonth
+    case onChagnedIndex(Int)
+  }
+  
+  func action(_ action: Action) {
+    switch action {
+    case .actionOnAppear:
+      onAppear()
+    case .dragGestur:
+        print("drag")
+//      dragGestureonEnded()
+    case .resetCurrentOffsetY:
+        print("drag")
+    case .moveToMonthly:
+      moveToMonthly()
+      case .moveToPreviousMonth:
+        moveToPreviousMonth()
+      case .moveToNextMonth:
+        moveToNextMonth()
+      case .onChagnedIndex(let index):
+        onChagnedIndex(index)
+    }
+  }
+  
+  func onAppear() {
+    self.getPermission()
+    self.fetchEvents()
+    self.fetchReminder()
+  }
+  
+  private func getPermission() {
+    eventManager.getPermission()
+  }
+  
+  private func fetchEvents() {
+    eventManager.getAllTaskforThisMonth(date: dateHolder.date, completionHandler: { [weak self] eventList in
+      DispatchQueue.main.async {
+        self?.events = eventList
+      }
+    })
+  }
+  
+  private func fetchReminder() {
+    reminderManager.getAllTaskforThisMonth(date: dateHolder.date, completionHandler: { [weak self] reminderList in
+      DispatchQueue.main.async {
+        self?.reminders = reminderList
+      }
+    })
+  }
+  
+  var allDatesForDisplay: [DateValue] {
+    return calendarHelper.extractDates(dateHolder.date)
+  }
+    
+  func filteredEvent(_ date: Date) -> [Event] {
+    eventManager.filterTask(events, date)
+  }
+  
+  func filteredReminder(_ date: Date) -> [Reminder] {
+    reminderManager.filterTask(reminders, date)
+  }
+  
+  var gridCloumnsCount: CGFloat {
+    return CGFloat(calendarHelper.extractDates(dateHolder.date).count + 1)
+  }
+
+  private func moveToPreviousMonth() {
+    currentOffsetX += offsetWidth
+      currentIndex -= 1
+  }
+  
+  private func moveToNextMonth() {
+    currentOffsetX -= offsetWidth
+    currentIndex += 1
+  }
+  
+  private func onChagnedIndex(_ changedIndex: Int) {
+    if changedIndex == 0 {
+      dateHolder.date = calendarHelper.minusDate(dateHolder.date)
+      currentOffsetX = -offsetWidth
+      currentIndex = 1
+    }
+    
+    if changedIndex == 2 {
+      dateHolder.date = calendarHelper.plusDate(dateHolder.date)
+      currentOffsetX = -offsetWidth
+      currentIndex = 1
+    }
+  }
+}

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackViewModel.swift
@@ -15,8 +15,6 @@ class WeeklyStackViewModel: ViewModelable {
   var moveToMonthly: () -> ()
   
   @Published var dateHolder: DateHolder
-  @Published var events: [Event]
-  @Published var reminders: [Reminder]
   
   @Published var currentOffsetX: CGFloat
   @Published var currentIndex: Int
@@ -26,8 +24,6 @@ class WeeklyStackViewModel: ViewModelable {
     eventManager: EventManager,
     reminderManager: ReminderManager,
     calendarHelper: CalendarCanDo,
-    events: [Event] = [],
-    reminders: [Reminder] = [],
     offsetWidth: CGFloat,
     currentIndex: Int = 1,
     moveToMonthly: @escaping () -> ()
@@ -37,8 +33,6 @@ class WeeklyStackViewModel: ViewModelable {
     self.eventManager = eventManager
     self.reminderManager = reminderManager
     self.calendarHelper = calendarHelper
-    self.events = events
-    self.reminders = reminders
     self.offsetWidth = offsetWidth
     self.currentIndex = currentIndex
     
@@ -47,6 +41,23 @@ class WeeklyStackViewModel: ViewModelable {
   
   var pastCurrentFutureDates: [Date] {
     return calendarHelper.extractPastCurrentFutureDates(dateHolder.date)
+  }
+  
+  var minimunCalendarWeekheight: CGFloat {
+    let dates = calendarHelper.extractMonthDates(dateHolder.date)
+      .map { (dateValue) -> String in
+        let isThisMonth = dateValue.isCurrentMonth ? "ThisMonth" : ""
+        let dayString = dateValue.date.day
+        return isThisMonth + dayString
+      }
+
+    let date = "ThisMonth" + dateHolder.date.day
+    
+    guard let index = dates.firstIndex(of: date) else {
+      return CGFloat(0)
+    }
+    
+    return CGFloat(index / 7) * CGFloat(16)
   }
   
   enum Action {
@@ -74,40 +85,16 @@ class WeeklyStackViewModel: ViewModelable {
   
   func onAppear() {
     self.getPermission()
-    self.fetchEvents()
-    self.fetchReminder()
+//    self.fetchEvents()
+//    self.fetchReminder()
   }
   
   private func getPermission() {
     eventManager.getPermission()
   }
   
-  private func fetchEvents() {
-    eventManager.getAllTaskforThisMonth(date: dateHolder.date, completionHandler: { [weak self] eventList in
-      DispatchQueue.main.async {
-        self?.events = eventList
-      }
-    })
-  }
-  
-  private func fetchReminder() {
-    reminderManager.getAllTaskforThisMonth(date: dateHolder.date, completionHandler: { [weak self] reminderList in
-      DispatchQueue.main.async {
-        self?.reminders = reminderList
-      }
-    })
-  }
-  
   var allDatesForDisplay: [DateValue] {
     return calendarHelper.extractDates(dateHolder.date)
-  }
-    
-  func filteredEvent(_ date: Date) -> [Event] {
-    eventManager.filterTask(events, date)
-  }
-  
-  func filteredReminder(_ date: Date) -> [Reminder] {
-    reminderManager.filterTask(reminders, date)
   }
   
   var gridCloumnsCount: CGFloat {
@@ -137,4 +124,10 @@ class WeeklyStackViewModel: ViewModelable {
       currentIndex = 1
     }
   }
+  
+  func extractMonthDates() -> [DateValue] {
+    calendarHelper.extractMonthDates(dateHolder.date)
+  }
+  
+
 }

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyStackViewModel.swift
@@ -61,7 +61,6 @@ class WeeklyStackViewModel: ViewModelable {
   }
   
   enum Action {
-    case actionOnAppear
     case moveToMonthly
     case moveToPreviousWeek
     case moveToNextWeek
@@ -70,8 +69,6 @@ class WeeklyStackViewModel: ViewModelable {
   
   func action(_ action: Action) {
     switch action {
-    case .actionOnAppear:
-      onAppear()
     case .moveToMonthly:
       moveToMonthly()
       case .moveToPreviousWeek:
@@ -81,16 +78,6 @@ class WeeklyStackViewModel: ViewModelable {
       case .onChagnedIndex(let index):
         onChagnedIndex(index)
     }
-  }
-  
-  func onAppear() {
-    self.getPermission()
-//    self.fetchEvents()
-//    self.fetchReminder()
-  }
-  
-  private func getPermission() {
-    eventManager.getPermission()
   }
   
   var allDatesForDisplay: [DateValue] {

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyView.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyView.swift
@@ -21,11 +21,15 @@ struct WeeklyView: View {
           
           let events = viewModel.filteredEvent(value.date)
           let reminders = viewModel.filteredReminder(value.date)
+          let clearedReminders = viewModel.filteredClearedReminder(value.date)
           
-          WeeklyCellView(viewModel: WeeklyCellViewModel(
-            dateValue: value,
-            allEvnets: events,
-            allReminders: reminders))
+          WeeklyCellView(viewModel: WeeklyCellViewModel(dateValue: value,
+                                                        allEvnets: events,
+                                                        dueDateReminders: reminders,
+                                                        clearedReminders: clearedReminders,
+                                                          eventManager: viewModel.eventManager,
+                                                        reminderManager: viewModel.reminderManager))
+          
           .padding(.horizontal, 10)
           .padding(.vertical, 6)
           .frame(width: geo.size.width / 1.9, height: geo.size.height / viewModel.gridCloumnsCount * 2)

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyView.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct WeeklyView: View {
+  @EnvironmentObject var coordinator: Coordinator<checkyRouter>
   @StateObject var viewModel: WeeklyViewModel
   
   var body: some View {
@@ -29,10 +30,13 @@ struct WeeklyView: View {
                                                         clearedReminders: clearedReminders,
                                                           eventManager: viewModel.eventManager,
                                                         reminderManager: viewModel.reminderManager))
-          
           .padding(.horizontal, 10)
           .padding(.vertical, 6)
           .frame(width: geo.size.width / 1.9, height: geo.size.height / viewModel.gridCloumnsCount * 2)
+          .onTapGesture {
+            coordinator.show(.daily(value.date, events, reminders, clearedReminders, viewModel.eventManager, viewModel.reminderManager))
+            print("tabbed!!!")
+          }
         }
       }
     }

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyView.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyView.swift
@@ -33,17 +33,8 @@ struct WeeklyView: View {
       }
     }
     .frame(maxHeight: .infinity)
-//    .gesture(
-//      DragGesture()
-//        .onChanged { value in
-//          viewModel.currentOffsetY = value.translation
-//        }
-//        .onEnded { value in
-//          viewModel.action(.dragGestur)
-//          withAnimation(.none) {
-//            viewModel.action(.resetCurrentOffsetY)
-//          }
-//        }
-//    )
+    .onAppear {
+      viewModel.action(.actionOnAppear)
+    }
   }
 }

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyView.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyView.swift
@@ -15,7 +15,7 @@ struct WeeklyView: View {
     
     GeometryReader { geo in
       LazyVGrid(columns: columns, spacing: 0) {
-        Text("달력 그릴 뷰")
+        Text("")
         
         ForEach(viewModel.allDatesForDisplay) { value in
           

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyView.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyView.swift
@@ -11,67 +11,39 @@ struct WeeklyView: View {
   @StateObject var viewModel: WeeklyViewModel
   
   var body: some View {
-    VStack(spacing: 1) {
-      HeaderView(viewModel: HeaderViewModel(dateHolder: viewModel.dateHolder, calendarHelper: viewModel.calendarHelper))
-      
-      HStack {
-        Spacer()
-        
-        Button("Monthly") { viewModel.action(.moveToMonthly) }
-          .buttonStyle(ToggleButtonStyle())
-          .padding(.top, 10)
-          .padding(.horizontal, 10)
-      }
-      
-      CalendarGrid
-      
-      Spacer()
-    }
-    .background(Color.backgroundGray)
-    .onAppear {
-      viewModel.action(.actionOnAppear)
-    }
-  }
-}
-
-extension WeeklyView {
-  var CalendarGrid: some View {
     let columns = Array(repeating: GridItem(.flexible(), spacing: 0, alignment: nil), count: 2)
     
-    var body: some View {
-      GeometryReader { geo in
-        LazyVGrid(columns: columns, spacing: 0) {
-          Text("달력 그릴 뷰")
+    GeometryReader { geo in
+      LazyVGrid(columns: columns, spacing: 0) {
+        Text("달력 그릴 뷰")
+        
+        ForEach(viewModel.allDatesForDisplay) { value in
           
-          ForEach(viewModel.allDatesForDisplay) { value in
-            
-            let events = viewModel.filteredEvent(value.date)
-            let reminders = viewModel.filteredReminder(value.date)
-            
-            WeeklyCellView(viewModel: WeeklyCellViewModel(
-              dateValue: value,
-              allEvnets: events,
-              allReminders: reminders))
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .frame(width: geo.size.width / 1.9, height: geo.size.height / viewModel.gridCloumnsCount * 2)
-          }
+          let events = viewModel.filteredEvent(value.date)
+          let reminders = viewModel.filteredReminder(value.date)
+          
+          WeeklyCellView(viewModel: WeeklyCellViewModel(
+            dateValue: value,
+            allEvnets: events,
+            allReminders: reminders))
+          .padding(.horizontal, 10)
+          .padding(.vertical, 6)
+          .frame(width: geo.size.width / 1.9, height: geo.size.height / viewModel.gridCloumnsCount * 2)
         }
       }
-      .frame(maxHeight: .infinity)
-      .gesture(
-        DragGesture()
-          .onChanged { value in
-            viewModel.currentOffsetY = value.translation
-          }
-          .onEnded { value in
-            viewModel.action(.dragGestur)
-            withAnimation(.none) {
-              viewModel.action(.resetCurrentOffsetY)
-            }
-          }
-      )
     }
-    return body
+    .frame(maxHeight: .infinity)
+//    .gesture(
+//      DragGesture()
+//        .onChanged { value in
+//          viewModel.currentOffsetY = value.translation
+//        }
+//        .onEnded { value in
+//          viewModel.action(.dragGestur)
+//          withAnimation(.none) {
+//            viewModel.action(.resetCurrentOffsetY)
+//          }
+//        }
+//    )
   }
 }

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyViewModel.swift
@@ -86,6 +86,10 @@ class WeeklyViewModel: ViewModelable {
     reminderManager.filterTask(reminders, date)
   }
   
+  func filteredClearedReminder(_ date: Date) -> [Reminder] {
+    reminderManager.filterClearTask(reminders, date)
+  }
+  
   var gridCloumnsCount: CGFloat {
     return CGFloat(calendarHelper.extractDates(date).count + 1)
   }

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyViewModel.swift
@@ -10,7 +10,7 @@ import Combine
 
 class WeeklyViewModel: ViewModelable {
   
-  @Published var dateHolder: DateHolder
+  @Published var date: Date
   @Published var events: [Event]
   @Published var reminders: [Reminder]
   @Published var currentOffsetY: CGSize
@@ -20,7 +20,7 @@ class WeeklyViewModel: ViewModelable {
   var moveToMonthly: () -> ()
   
   init(
-    dateHolder: DateHolder,
+    date: Date,
     eventManager: EventManager,
     reminderManager: ReminderManager,
     calendarHelper: CalendarCanDo,
@@ -30,7 +30,7 @@ class WeeklyViewModel: ViewModelable {
     moveToMonthly: @escaping () -> ()
   ) {
     self.moveToMonthly = moveToMonthly
-    self.dateHolder = dateHolder
+    self.date = date
     self.eventManager = eventManager
     self.reminderManager = reminderManager
     self.calendarHelper = calendarHelper
@@ -70,7 +70,7 @@ class WeeklyViewModel: ViewModelable {
   }
   
   private func fetchEvents() {
-    eventManager.getAllTaskforThisMonth(date: dateHolder.date, completionHandler: { [weak self] eventList in
+    eventManager.getAllTaskforThisMonth(date: date, completionHandler: { [weak self] eventList in
       DispatchQueue.main.async {
         self?.events = eventList
       }
@@ -78,7 +78,7 @@ class WeeklyViewModel: ViewModelable {
   }
   
   private func fetchReminder() {
-    reminderManager.getAllTaskforThisMonth(date: dateHolder.date, completionHandler: { [weak self] reminderList in
+    reminderManager.getAllTaskforThisMonth(date: date, completionHandler: { [weak self] reminderList in
       DispatchQueue.main.async {
         self?.reminders = reminderList
       }
@@ -86,7 +86,7 @@ class WeeklyViewModel: ViewModelable {
   }
   
   var allDatesForDisplay: [DateValue] {
-    return calendarHelper.extractDates(dateHolder.date)
+    return calendarHelper.extractDates(date)
   }
     
   func filteredEvent(_ date: Date) -> [Event] {
@@ -98,15 +98,15 @@ class WeeklyViewModel: ViewModelable {
   }
   
   var gridCloumnsCount: CGFloat {
-    return CGFloat(calendarHelper.extractDates(dateHolder.date).count + 1)
+    return CGFloat(calendarHelper.extractDates(date).count + 1)
   }
   
   func dragGestureonEnded() {
     guard currentOffsetY.height < 0 else {
-      dateHolder.date = calendarHelper.minusDate(dateHolder.date)
+      date = calendarHelper.minusDate(date)
       return
     }
-    dateHolder.date = calendarHelper.plusDate(dateHolder.date)
+    date = calendarHelper.plusDate(date)
   }
   
   func resetCurrentOffsetY() {

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyViewModel.swift
@@ -9,11 +9,11 @@ import Foundation
 import Combine
 
 class WeeklyViewModel: ViewModelable {
-  
   @Published var date: Date
   @Published var events: [Event]
   @Published var reminders: [Reminder]
   @Published var currentOffsetY: CGSize
+  
   let eventManager: EventManager
   let reminderManager: ReminderManager
   let calendarHelper: CalendarCanDo

--- a/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyViewModel.swift
+++ b/checky/checky/View/MainView/CalendarView/WeeklyView/WeeklyViewModel.swift
@@ -17,7 +17,6 @@ class WeeklyViewModel: ViewModelable {
   let eventManager: EventManager
   let reminderManager: ReminderManager
   let calendarHelper: CalendarCanDo
-  var moveToMonthly: () -> ()
   
   init(
     date: Date,
@@ -26,10 +25,8 @@ class WeeklyViewModel: ViewModelable {
     calendarHelper: CalendarCanDo,
     currentOffsetY: CGSize = .zero,
     events: [Event] = [],
-    reminders: [Reminder] = [],
-    moveToMonthly: @escaping () -> ()
+    reminders: [Reminder] = []
   ) {
-    self.moveToMonthly = moveToMonthly
     self.date = date
     self.eventManager = eventManager
     self.reminderManager = reminderManager
@@ -39,23 +36,19 @@ class WeeklyViewModel: ViewModelable {
     self.reminders = reminders
   }
   
+  var allDatesForDisplay: [DateValue] {
+    return calendarHelper.extractDates(date)
+  }
+  
   enum Action {
     case actionOnAppear
-    case dragGestur
-    case resetCurrentOffsetY
-    case moveToMonthly
+
   }
   
   func action(_ action: Action) {
     switch action {
     case .actionOnAppear:
       onAppear()
-    case .dragGestur:
-      dragGestureonEnded()
-    case .resetCurrentOffsetY:
-      resetCurrentOffsetY()
-    case .moveToMonthly:
-      moveToMonthly()
     }
   }
   
@@ -84,10 +77,6 @@ class WeeklyViewModel: ViewModelable {
       }
     })
   }
-  
-  var allDatesForDisplay: [DateValue] {
-    return calendarHelper.extractDates(date)
-  }
     
   func filteredEvent(_ date: Date) -> [Event] {
     eventManager.filterTask(events, date)
@@ -101,17 +90,6 @@ class WeeklyViewModel: ViewModelable {
     return CGFloat(calendarHelper.extractDates(date).count + 1)
   }
   
-  func dragGestureonEnded() {
-    guard currentOffsetY.height < 0 else {
-      date = calendarHelper.minusDate(date)
-      return
-    }
-    date = calendarHelper.plusDate(date)
-  }
-  
-  func resetCurrentOffsetY() {
-    currentOffsetY = .zero
-  }
 }
 
 protocol ViewModelable: ObservableObject {

--- a/checky/checky/View/MainView/CheckyMainView.swift
+++ b/checky/checky/View/MainView/CheckyMainView.swift
@@ -15,6 +15,7 @@ struct CheckyMainView: View {
     VStack {
       CustomTabBarContainerView(selection: $checkyMainViewModel.tabSelection) {
         CalendarView()
+          .environmentObject(coordinator)
           .tabBarItem(tab: .calendar, selection: $checkyMainViewModel.tabSelection)
         Color.red
           .tabBarItem(tab: .reminder, selection: $checkyMainViewModel.tabSelection)

--- a/checky/checky/View/MainView/CheckyMainViewModel.swift
+++ b/checky/checky/View/MainView/CheckyMainViewModel.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 class CheckyMainViewModel: ObservableObject {
-  
   @Published var selection: String = "home"
   @Published var tabSelection: TabBarItem = .calendar
   

--- a/checky/checky/View/ReminderCreateView/ReminderCreateAndEditView.swift
+++ b/checky/checky/View/ReminderCreateView/ReminderCreateAndEditView.swift
@@ -10,7 +10,11 @@ import SwiftUI
 struct ReminderCreateAndEditView: View {
   @EnvironmentObject var coordinator: Coordinator<checkyRouter>
 
-  @ObservedObject var viewModel = ReminderCreateAndEditViewModel(mode: .create, reminderManager: ReminderManager())
+  @ObservedObject var viewModel: ReminderCreateAndEditViewModel
+  
+  init(viewModel: ReminderCreateAndEditViewModel) {
+    self.viewModel = viewModel
+  }
   
   var body: some View {
     VStack {


### PR DESCRIPTION
@Taeangel 
안녕하세요 태엔젤, 구현 완료 하여 PR 보냅니다. 

## 구현한 사항

DailyView 를 구현하고 Montly Weekly 그리고 edit view 와 연동을 진행하였습니다. 
cell 에 대한 전반적인 디자인도 수정하였습니다. 

미리알림의 경우 HighPriority 를 가진 객체만 화면에 보여지도록 설정했습니다. 

## 변경된 데일리 뷰 기획 

기획에 대해서 변경된 부분이 있습니다. 

처음에 Daily View 는 시간을 기준으로 이벤트와 미리알림을 보여줄 예정이었으나, 
미리알림의 마감기한 이라는 것이 실제로 작업을 이행한 시간이 아니다 보니, 마감 기한을 기준으로 이벤트와 같은 타임라인에 넣는 것이 조금 이상하다고 판단을 했습니다. 
이벤트와 미리알림을 나눠서 작업을 진행했습니다. 

특히 미리알림의 경우 특정한 시간이 큰 의미를 끼치진 않는다고 생각해서 마감 시간 뷰에 띄우진 않았습니다. 

## 추후 수정해야 할 내용 
### WeeklyView  MonthlyView 연동과 오늘로 돌아오기
우선은 WeeklyView 와 MonthlyView 가 다른 데이터 홀더를 사용하고 있어 뷰 이동시 항상 오늘 날짜로 이동이 되고 서로 연동되지 않습니다. 

만약 위의 것을 구현할 경우 오늘로 돌아오는 버튼을 만들어야 하는데, 데이터 홀더의 값을 오늘로 넣어주어도 뷰들이 즉각적으로 반응하지 않습니다. 

### 앱 로딩 시간 
시뮬에서 앱을 돌릴 때 보다 실제로 핸드폰에 로드 해보니, MonthlyView 로 이동 할 떄마다, 이벤트들이 로딩 되는데 3초 정도의 시간이 걸립니다. 
3초가 생각보가 길게 느껴지기도 하고, 또 뷰가 처음 로드 될때만 그러는 것이 아니라 MonthlyView 로 이동 할 때 마다 그러니 보완이 필요할 것 같습니다. 



